### PR TITLE
Power, Current, Resistance

### DIFF
--- a/internal/aez/ccd_power_regulators.go
+++ b/internal/aez/ccd_power_regulators.go
@@ -3,6 +3,7 @@ package aez
 import (
 	"encoding/binary"
 	"io"
+	"math"
 )
 
 //CPRU structure
@@ -25,7 +26,67 @@ type CPRU struct {
 	VOD3   uint16 // CCD3 Output Drain Voltage 0..4095
 }
 
+//CPRUReport structure
+type CPRUReport struct {
+	VGATE0 float64 // CCD0 Gate Voltage
+	VSUBS0 float64 // CCD0 Substrate Voltage
+	VRD0   float64 // CCD0 Reset transistor Drain Voltage
+	VOD0   float64 // CCD0 Output Drain Voltage
+	VGATE1 float64 // CCD1 Gate Voltage
+	VSUBS1 float64 // CCD1 Substrate Voltage
+	VRD1   float64 // CCD1 Reset transistor Drain Voltage
+	VOD1   float64 // CCD1 Output Drain Voltage
+	VGATE2 float64 // CCD2 Gate Voltage
+	VSUBS2 float64 // CCD2 Substrate Voltage
+	VRD2   float64 // CCD2 Reset transistor Drain Voltage
+	VOD2   float64 // CCD2 Output Drain Voltage
+	VGATE3 float64 // CCD3 Gate Voltage
+	VSUBS3 float64 // CCD3 Substrate Voltage
+	VRD3   float64 // CCD3 Reset transistor Drain Voltage
+	VOD3   float64 // CCD3 Output Drain Voltage
+}
+
 // Read CRPU
 func (cpru *CPRU) Read(buf io.Reader) error {
 	return binary.Read(buf, binary.BigEndian, cpru)
+}
+
+var voltageConstant float64 = 2.5 / (math.Pow(2, 12) - 1)
+
+func gateVoltage(data uint16) float64 {
+	return voltageConstant * float64(data) * 10
+}
+
+func subsVoltage(data uint16) float64 {
+	return voltageConstant * float64(data) * 11 / 1.5
+}
+
+func rdVoltage(data uint16) float64 {
+	return voltageConstant * float64(data) * 17 / 1.5
+}
+
+func odVoltage(data uint16) float64 {
+	return voltageConstant * float64(data) * 32 / 1.5
+}
+
+// Report transforms CPRU data to useful units
+func (cpru *CPRU) Report() CPRUReport {
+	return CPRUReport{
+		VGATE0: gateVoltage(cpru.VGATE0),
+		VSUBS0: subsVoltage(cpru.VSUBS0),
+		VRD0:   rdVoltage(cpru.VRD0),
+		VOD0:   odVoltage(cpru.VOD0),
+		VGATE1: gateVoltage(cpru.VGATE1),
+		VSUBS1: subsVoltage(cpru.VSUBS1),
+		VRD1:   rdVoltage(cpru.VRD1),
+		VOD1:   odVoltage(cpru.VOD1),
+		VGATE2: gateVoltage(cpru.VGATE2),
+		VSUBS2: subsVoltage(cpru.VSUBS2),
+		VRD2:   rdVoltage(cpru.VRD2),
+		VOD2:   odVoltage(cpru.VOD2),
+		VGATE3: gateVoltage(cpru.VGATE3),
+		VSUBS3: subsVoltage(cpru.VSUBS3),
+		VRD3:   rdVoltage(cpru.VRD3),
+		VOD3:   odVoltage(cpru.VOD3),
+	}
 }

--- a/internal/aez/ccd_power_regulators.go
+++ b/internal/aez/ccd_power_regulators.go
@@ -6,24 +6,50 @@ import (
 	"math"
 )
 
+type gate uint16
+
+var voltageConstant float64 = 2.5 / (math.Pow(2, 12) - 1)
+
+func (data gate) voltage() float64 {
+	return voltageConstant * float64(data) * 10
+}
+
+type subs uint16
+
+func (data subs) voltage() float64 {
+	return voltageConstant * float64(data) * 11 / 1.5
+}
+
+type rd uint16
+
+func (data rd) voltage() float64 {
+	return voltageConstant * float64(data) * 17 / 1.5
+}
+
+type od uint16
+
+func (data od) voltage() float64 {
+	return voltageConstant * float64(data) * 32 / 1.5
+}
+
 //CPRU structure
 type CPRU struct {
-	VGATE0 uint16 // CCD0 Gate Voltage 0..4095
-	VSUBS0 uint16 // CCD0 Substrate Voltage 0..4095
-	VRD0   uint16 // CCD0 Reset transistor Drain Voltage 0..4095
-	VOD0   uint16 // CCD0 Output Drain Voltage 0..4095
-	VGATE1 uint16 // CCD1 Gate Voltage 0..4095
-	VSUBS1 uint16 // CCD1 Substrate Voltage 0..4095
-	VRD1   uint16 // CCD1 Reset transistor Drain Voltage 0..4095
-	VOD1   uint16 // CCD1 Output Drain Voltage 0..4095
-	VGATE2 uint16 // CCD2 Gate Voltage 0..4095
-	VSUBS2 uint16 // CCD2 Substrate Voltage 0..4095
-	VRD2   uint16 // CCD2 Reset transistor Drain Voltage 0..4095
-	VOD2   uint16 // CCD2 Output Drain Voltage 0..4095
-	VGATE3 uint16 // CCD3 Gate Voltage 0..4095
-	VSUBS3 uint16 // CCD3 Substrate Voltage 0..4095
-	VRD3   uint16 // CCD3 Reset transistor Drain Voltage 0..4095
-	VOD3   uint16 // CCD3 Output Drain Voltage 0..4095
+	VGATE0 gate // CCD0 Gate Voltage 0..4095
+	VSUBS0 subs // CCD0 Substrate Voltage 0..4095
+	VRD0   rd   // CCD0 Reset transistor Drain Voltage 0..4095
+	VOD0   od   // CCD0 Output Drain Voltage 0..4095
+	VGATE1 gate // CCD1 Gate Voltage 0..4095
+	VSUBS1 subs // CCD1 Substrate Voltage 0..4095
+	VRD1   rd   // CCD1 Reset transistor Drain Voltage 0..4095
+	VOD1   od   // CCD1 Output Drain Voltage 0..4095
+	VGATE2 gate // CCD2 Gate Voltage 0..4095
+	VSUBS2 subs // CCD2 Substrate Voltage 0..4095
+	VRD2   rd   // CCD2 Reset transistor Drain Voltage 0..4095
+	VOD2   od   // CCD2 Output Drain Voltage 0..4095
+	VGATE3 gate // CCD3 Gate Voltage 0..4095
+	VSUBS3 subs // CCD3 Substrate Voltage 0..4095
+	VRD3   rd   // CCD3 Reset transistor Drain Voltage 0..4095
+	VOD3   od   // CCD3 Output Drain Voltage 0..4095
 }
 
 //CPRUReport structure
@@ -51,42 +77,24 @@ func (cpru *CPRU) Read(buf io.Reader) error {
 	return binary.Read(buf, binary.BigEndian, cpru)
 }
 
-var voltageConstant float64 = 2.5 / (math.Pow(2, 12) - 1)
-
-func gateVoltage(data uint16) float64 {
-	return voltageConstant * float64(data) * 10
-}
-
-func subsVoltage(data uint16) float64 {
-	return voltageConstant * float64(data) * 11 / 1.5
-}
-
-func rdVoltage(data uint16) float64 {
-	return voltageConstant * float64(data) * 17 / 1.5
-}
-
-func odVoltage(data uint16) float64 {
-	return voltageConstant * float64(data) * 32 / 1.5
-}
-
 // Report transforms CPRU data to useful units
 func (cpru *CPRU) Report() CPRUReport {
 	return CPRUReport{
-		VGATE0: gateVoltage(cpru.VGATE0),
-		VSUBS0: subsVoltage(cpru.VSUBS0),
-		VRD0:   rdVoltage(cpru.VRD0),
-		VOD0:   odVoltage(cpru.VOD0),
-		VGATE1: gateVoltage(cpru.VGATE1),
-		VSUBS1: subsVoltage(cpru.VSUBS1),
-		VRD1:   rdVoltage(cpru.VRD1),
-		VOD1:   odVoltage(cpru.VOD1),
-		VGATE2: gateVoltage(cpru.VGATE2),
-		VSUBS2: subsVoltage(cpru.VSUBS2),
-		VRD2:   rdVoltage(cpru.VRD2),
-		VOD2:   odVoltage(cpru.VOD2),
-		VGATE3: gateVoltage(cpru.VGATE3),
-		VSUBS3: subsVoltage(cpru.VSUBS3),
-		VRD3:   rdVoltage(cpru.VRD3),
-		VOD3:   odVoltage(cpru.VOD3),
+		VGATE0: cpru.VGATE0.voltage(),
+		VSUBS0: cpru.VSUBS0.voltage(),
+		VRD0:   cpru.VRD0.voltage(),
+		VOD0:   cpru.VOD0.voltage(),
+		VGATE1: cpru.VGATE1.voltage(),
+		VSUBS1: cpru.VSUBS1.voltage(),
+		VRD1:   cpru.VRD1.voltage(),
+		VOD1:   cpru.VOD1.voltage(),
+		VGATE2: cpru.VGATE2.voltage(),
+		VSUBS2: cpru.VSUBS2.voltage(),
+		VRD2:   cpru.VRD2.voltage(),
+		VOD2:   cpru.VOD2.voltage(),
+		VGATE3: cpru.VGATE3.voltage(),
+		VSUBS3: cpru.VSUBS3.voltage(),
+		VRD3:   cpru.VRD3.voltage(),
+		VOD3:   cpru.VOD3.voltage(),
 	}
 }

--- a/internal/aez/ccd_power_regulators_test.go
+++ b/internal/aez/ccd_power_regulators_test.go
@@ -31,6 +31,20 @@ func TestCPRU_Report(t *testing.T) {
 	}{
 		{"Transforms VGATE0", fields{VGATE0: 10}, CPRUReport{VGATE0: gate(10).voltage()}},
 		{"Transforms VSUBS0", fields{VSUBS0: 10}, CPRUReport{VSUBS0: subs(10).voltage()}},
+		{"Transforms VRD0", fields{VRD0: 10}, CPRUReport{VRD0: rd(10).voltage()}},
+		{"Transforms VOD0", fields{VOD0: 10}, CPRUReport{VOD0: od(10).voltage()}},
+		{"Transforms VGATE1", fields{VGATE1: 10}, CPRUReport{VGATE1: gate(10).voltage()}},
+		{"Transforms VSUBS1", fields{VSUBS1: 10}, CPRUReport{VSUBS1: subs(10).voltage()}},
+		{"Transforms VRD1", fields{VRD1: 10}, CPRUReport{VRD1: rd(10).voltage()}},
+		{"Transforms VOD1", fields{VOD1: 10}, CPRUReport{VOD1: od(10).voltage()}},
+		{"Transforms VGATE2", fields{VGATE2: 10}, CPRUReport{VGATE2: gate(10).voltage()}},
+		{"Transforms VSUBS2", fields{VSUBS2: 10}, CPRUReport{VSUBS2: subs(10).voltage()}},
+		{"Transforms VRD2", fields{VRD2: 10}, CPRUReport{VRD2: rd(10).voltage()}},
+		{"Transforms VOD2", fields{VOD2: 10}, CPRUReport{VOD2: od(10).voltage()}},
+		{"Transforms VGATE3", fields{VGATE3: 10}, CPRUReport{VGATE3: gate(10).voltage()}},
+		{"Transforms VSUBS3", fields{VSUBS3: 10}, CPRUReport{VSUBS3: subs(10).voltage()}},
+		{"Transforms VRD3", fields{VRD3: 10}, CPRUReport{VRD3: rd(10).voltage()}},
+		{"Transforms VOD3", fields{VOD3: 10}, CPRUReport{VOD3: od(10).voltage()}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/aez/ccd_power_regulators_test.go
+++ b/internal/aez/ccd_power_regulators_test.go
@@ -1,0 +1,59 @@
+package aez
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCPRU_Report(t *testing.T) {
+	type fields struct {
+		VGATE0 uint16
+		VSUBS0 uint16
+		VRD0   uint16
+		VOD0   uint16
+		VGATE1 uint16
+		VSUBS1 uint16
+		VRD1   uint16
+		VOD1   uint16
+		VGATE2 uint16
+		VSUBS2 uint16
+		VRD2   uint16
+		VOD2   uint16
+		VGATE3 uint16
+		VSUBS3 uint16
+		VRD3   uint16
+		VOD3   uint16
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   CPRUReport
+	}{
+		{"Transforms VGATE0", fields{VGATE0: 10}, CPRUReport{VGATE0: gateVoltage(10)}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cpru := &CPRU{
+				VGATE0: tt.fields.VGATE0,
+				VSUBS0: tt.fields.VSUBS0,
+				VRD0:   tt.fields.VRD0,
+				VOD0:   tt.fields.VOD0,
+				VGATE1: tt.fields.VGATE1,
+				VSUBS1: tt.fields.VSUBS1,
+				VRD1:   tt.fields.VRD1,
+				VOD1:   tt.fields.VOD1,
+				VGATE2: tt.fields.VGATE2,
+				VSUBS2: tt.fields.VSUBS2,
+				VRD2:   tt.fields.VRD2,
+				VOD2:   tt.fields.VOD2,
+				VGATE3: tt.fields.VGATE3,
+				VSUBS3: tt.fields.VSUBS3,
+				VRD3:   tt.fields.VRD3,
+				VOD3:   tt.fields.VOD3,
+			}
+			if got := cpru.Report(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CPRU.Report() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/aez/ccd_power_regulators_test.go
+++ b/internal/aez/ccd_power_regulators_test.go
@@ -7,29 +7,30 @@ import (
 
 func TestCPRU_Report(t *testing.T) {
 	type fields struct {
-		VGATE0 uint16
-		VSUBS0 uint16
-		VRD0   uint16
-		VOD0   uint16
-		VGATE1 uint16
-		VSUBS1 uint16
-		VRD1   uint16
-		VOD1   uint16
-		VGATE2 uint16
-		VSUBS2 uint16
-		VRD2   uint16
-		VOD2   uint16
-		VGATE3 uint16
-		VSUBS3 uint16
-		VRD3   uint16
-		VOD3   uint16
+		VGATE0 gate
+		VSUBS0 subs
+		VRD0   rd
+		VOD0   od
+		VGATE1 gate
+		VSUBS1 subs
+		VRD1   rd
+		VOD1   od
+		VGATE2 gate
+		VSUBS2 subs
+		VRD2   rd
+		VOD2   od
+		VGATE3 gate
+		VSUBS3 subs
+		VRD3   rd
+		VOD3   od
 	}
 	tests := []struct {
 		name   string
 		fields fields
 		want   CPRUReport
 	}{
-		{"Transforms VGATE0", fields{VGATE0: 10}, CPRUReport{VGATE0: gateVoltage(10)}},
+		{"Transforms VGATE0", fields{VGATE0: 10}, CPRUReport{VGATE0: gate(10).voltage()}},
+		{"Transforms VSUBS0", fields{VSUBS0: 10}, CPRUReport{VSUBS0: subs(10).voltage()}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/aez/heater_regulators.go
+++ b/internal/aez/heater_regulators.go
@@ -33,7 +33,69 @@ type HTR struct {
 	HTR8OD uint16
 }
 
+//HTRReport housekeeping report returns data on all heater regulators in useful units.
+type HTRReport struct {
+	HTR1A  float64 // Heater 1 Temperature sense A voltage
+	HTR1B  float64 // Heater 1 Temperature sense B voltage
+	HTR1OD float64 // Heater 1 Output Drive setting voltage
+	HTR2A  float64
+	HTR2B  float64
+	HTR2OD float64
+	HTR3A  float64
+	HTR3B  float64
+	HTR3OD float64
+	HTR4A  float64
+	HTR4B  float64
+	HTR4OD float64
+	HTR5A  float64
+	HTR5B  float64
+	HTR5OD float64
+	HTR6A  float64
+	HTR6B  float64
+	HTR6OD float64
+	HTR7A  float64
+	HTR7B  float64
+	HTR7OD float64
+	HTR8A  float64
+	HTR8B  float64
+	HTR8OD float64
+}
+
 // Read HTR
 func (htr *HTR) Read(buf io.Reader) error {
 	return binary.Read(buf, binary.BigEndian, htr)
+}
+
+func htrVoltage(data uint16) float64 {
+	return voltageConstant * float64(data)
+}
+
+// Report returns a HTRReport with useful units
+func (htr *HTR) Report() HTRReport {
+	return HTRReport{
+		HTR1A:  htrVoltage(htr.HTR1A),
+		HTR1B:  htrVoltage(htr.HTR1B),
+		HTR1OD: htrVoltage(htr.HTR1OD),
+		HTR2A:  htrVoltage(htr.HTR2A),
+		HTR2B:  htrVoltage(htr.HTR2B),
+		HTR2OD: htrVoltage(htr.HTR2OD),
+		HTR3A:  htrVoltage(htr.HTR3A),
+		HTR3B:  htrVoltage(htr.HTR3B),
+		HTR3OD: htrVoltage(htr.HTR3OD),
+		HTR4A:  htrVoltage(htr.HTR4A),
+		HTR4B:  htrVoltage(htr.HTR4B),
+		HTR4OD: htrVoltage(htr.HTR4OD),
+		HTR5A:  htrVoltage(htr.HTR5A),
+		HTR5B:  htrVoltage(htr.HTR5B),
+		HTR5OD: htrVoltage(htr.HTR5OD),
+		HTR6A:  htrVoltage(htr.HTR6A),
+		HTR6B:  htrVoltage(htr.HTR6B),
+		HTR6OD: htrVoltage(htr.HTR6OD),
+		HTR7A:  htrVoltage(htr.HTR7A),
+		HTR7B:  htrVoltage(htr.HTR7B),
+		HTR7OD: htrVoltage(htr.HTR7OD),
+		HTR8A:  htrVoltage(htr.HTR8A),
+		HTR8B:  htrVoltage(htr.HTR8B),
+		HTR8OD: htrVoltage(htr.HTR8OD),
+	}
 }

--- a/internal/aez/heater_regulators.go
+++ b/internal/aez/heater_regulators.go
@@ -11,6 +11,10 @@ func (data htr) voltage() float64 {
 	return voltageConstant * float64(data)
 }
 
+func (data htr) resistance() float64 {
+	return 3.3*3900/data.voltage() - 3900
+}
+
 //HTR housekeeping report returns data on all heater regulators.
 type HTR struct {
 	HTR1A  htr // Heater 1 Temperature sense A 0..4095
@@ -42,7 +46,7 @@ type HTR struct {
 //HTRReport housekeeping report returns data on all heater regulators in useful units.
 type HTRReport struct {
 	HTR1A  float64 // Heater 1 Temperature sense A voltage
-	HTR1B  float64 // Heater 1 Temperature sense B voltage
+	HTR1B  float64 // Heater 1 Temperature sense B resistance
 	HTR1OD float64 // Heater 1 Output Drive setting voltage
 	HTR2A  float64
 	HTR2B  float64
@@ -76,28 +80,28 @@ func (htr *HTR) Read(buf io.Reader) error {
 func (htr *HTR) Report() HTRReport {
 	return HTRReport{
 		HTR1A:  htr.HTR1A.voltage(),
-		HTR1B:  htr.HTR1B.voltage(),
+		HTR1B:  htr.HTR1B.resistance(),
 		HTR1OD: htr.HTR1OD.voltage(),
 		HTR2A:  htr.HTR2A.voltage(),
-		HTR2B:  htr.HTR2B.voltage(),
+		HTR2B:  htr.HTR2B.resistance(),
 		HTR2OD: htr.HTR2OD.voltage(),
 		HTR3A:  htr.HTR3A.voltage(),
-		HTR3B:  htr.HTR3B.voltage(),
+		HTR3B:  htr.HTR3B.resistance(),
 		HTR3OD: htr.HTR3OD.voltage(),
 		HTR4A:  htr.HTR4A.voltage(),
-		HTR4B:  htr.HTR4B.voltage(),
+		HTR4B:  htr.HTR4B.resistance(),
 		HTR4OD: htr.HTR4OD.voltage(),
 		HTR5A:  htr.HTR5A.voltage(),
-		HTR5B:  htr.HTR5B.voltage(),
+		HTR5B:  htr.HTR5B.resistance(),
 		HTR5OD: htr.HTR5OD.voltage(),
 		HTR6A:  htr.HTR6A.voltage(),
-		HTR6B:  htr.HTR6B.voltage(),
+		HTR6B:  htr.HTR6B.resistance(),
 		HTR6OD: htr.HTR6OD.voltage(),
 		HTR7A:  htr.HTR7A.voltage(),
-		HTR7B:  htr.HTR7B.voltage(),
+		HTR7B:  htr.HTR7B.resistance(),
 		HTR7OD: htr.HTR7OD.voltage(),
 		HTR8A:  htr.HTR8A.voltage(),
-		HTR8B:  htr.HTR8B.voltage(),
+		HTR8B:  htr.HTR8B.resistance(),
 		HTR8OD: htr.HTR8OD.voltage(),
 	}
 }

--- a/internal/aez/heater_regulators.go
+++ b/internal/aez/heater_regulators.go
@@ -5,32 +5,38 @@ import (
 	"io"
 )
 
+type htr uint16
+
+func (data htr) voltage() float64 {
+	return voltageConstant * float64(data)
+}
+
 //HTR housekeeping report returns data on all heater regulators.
 type HTR struct {
-	HTR1A  uint16 // Heater 1 Temperature sense A 0..4095
-	HTR1B  uint16 // Heater 1 Temperature sense B 0..4095
-	HTR1OD uint16 // Heater 1 Output Drive setting 0..4095
-	HTR2A  uint16
-	HTR2B  uint16
-	HTR2OD uint16
-	HTR3A  uint16
-	HTR3B  uint16
-	HTR3OD uint16
-	HTR4A  uint16
-	HTR4B  uint16
-	HTR4OD uint16
-	HTR5A  uint16
-	HTR5B  uint16
-	HTR5OD uint16
-	HTR6A  uint16
-	HTR6B  uint16
-	HTR6OD uint16
-	HTR7A  uint16
-	HTR7B  uint16
-	HTR7OD uint16
-	HTR8A  uint16
-	HTR8B  uint16
-	HTR8OD uint16
+	HTR1A  htr // Heater 1 Temperature sense A 0..4095
+	HTR1B  htr // Heater 1 Temperature sense B 0..4095
+	HTR1OD htr // Heater 1 Output Drive setting 0..4095
+	HTR2A  htr
+	HTR2B  htr
+	HTR2OD htr
+	HTR3A  htr
+	HTR3B  htr
+	HTR3OD htr
+	HTR4A  htr
+	HTR4B  htr
+	HTR4OD htr
+	HTR5A  htr
+	HTR5B  htr
+	HTR5OD htr
+	HTR6A  htr
+	HTR6B  htr
+	HTR6OD htr
+	HTR7A  htr
+	HTR7B  htr
+	HTR7OD htr
+	HTR8A  htr
+	HTR8B  htr
+	HTR8OD htr
 }
 
 //HTRReport housekeeping report returns data on all heater regulators in useful units.
@@ -66,36 +72,32 @@ func (htr *HTR) Read(buf io.Reader) error {
 	return binary.Read(buf, binary.BigEndian, htr)
 }
 
-func htrVoltage(data uint16) float64 {
-	return voltageConstant * float64(data)
-}
-
 // Report returns a HTRReport with useful units
 func (htr *HTR) Report() HTRReport {
 	return HTRReport{
-		HTR1A:  htrVoltage(htr.HTR1A),
-		HTR1B:  htrVoltage(htr.HTR1B),
-		HTR1OD: htrVoltage(htr.HTR1OD),
-		HTR2A:  htrVoltage(htr.HTR2A),
-		HTR2B:  htrVoltage(htr.HTR2B),
-		HTR2OD: htrVoltage(htr.HTR2OD),
-		HTR3A:  htrVoltage(htr.HTR3A),
-		HTR3B:  htrVoltage(htr.HTR3B),
-		HTR3OD: htrVoltage(htr.HTR3OD),
-		HTR4A:  htrVoltage(htr.HTR4A),
-		HTR4B:  htrVoltage(htr.HTR4B),
-		HTR4OD: htrVoltage(htr.HTR4OD),
-		HTR5A:  htrVoltage(htr.HTR5A),
-		HTR5B:  htrVoltage(htr.HTR5B),
-		HTR5OD: htrVoltage(htr.HTR5OD),
-		HTR6A:  htrVoltage(htr.HTR6A),
-		HTR6B:  htrVoltage(htr.HTR6B),
-		HTR6OD: htrVoltage(htr.HTR6OD),
-		HTR7A:  htrVoltage(htr.HTR7A),
-		HTR7B:  htrVoltage(htr.HTR7B),
-		HTR7OD: htrVoltage(htr.HTR7OD),
-		HTR8A:  htrVoltage(htr.HTR8A),
-		HTR8B:  htrVoltage(htr.HTR8B),
-		HTR8OD: htrVoltage(htr.HTR8OD),
+		HTR1A:  htr.HTR1A.voltage(),
+		HTR1B:  htr.HTR1B.voltage(),
+		HTR1OD: htr.HTR1OD.voltage(),
+		HTR2A:  htr.HTR2A.voltage(),
+		HTR2B:  htr.HTR2B.voltage(),
+		HTR2OD: htr.HTR2OD.voltage(),
+		HTR3A:  htr.HTR3A.voltage(),
+		HTR3B:  htr.HTR3B.voltage(),
+		HTR3OD: htr.HTR3OD.voltage(),
+		HTR4A:  htr.HTR4A.voltage(),
+		HTR4B:  htr.HTR4B.voltage(),
+		HTR4OD: htr.HTR4OD.voltage(),
+		HTR5A:  htr.HTR5A.voltage(),
+		HTR5B:  htr.HTR5B.voltage(),
+		HTR5OD: htr.HTR5OD.voltage(),
+		HTR6A:  htr.HTR6A.voltage(),
+		HTR6B:  htr.HTR6B.voltage(),
+		HTR6OD: htr.HTR6OD.voltage(),
+		HTR7A:  htr.HTR7A.voltage(),
+		HTR7B:  htr.HTR7B.voltage(),
+		HTR7OD: htr.HTR7OD.voltage(),
+		HTR8A:  htr.HTR8A.voltage(),
+		HTR8B:  htr.HTR8B.voltage(),
+		HTR8OD: htr.HTR8OD.voltage(),
 	}
 }

--- a/internal/aez/heater_regulators_test.go
+++ b/internal/aez/heater_regulators_test.go
@@ -1,0 +1,102 @@
+package aez
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestHTR_Report(t *testing.T) {
+	type fields struct {
+		HTR1A  htr
+		HTR1B  htr
+		HTR1OD htr
+		HTR2A  htr
+		HTR2B  htr
+		HTR2OD htr
+		HTR3A  htr
+		HTR3B  htr
+		HTR3OD htr
+		HTR4A  htr
+		HTR4B  htr
+		HTR4OD htr
+		HTR5A  htr
+		HTR5B  htr
+		HTR5OD htr
+		HTR6A  htr
+		HTR6B  htr
+		HTR6OD htr
+		HTR7A  htr
+		HTR7B  htr
+		HTR7OD htr
+		HTR8A  htr
+		HTR8B  htr
+		HTR8OD htr
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		field  string
+		want   float64
+	}{
+		{"HTR1A is voltage", fields{HTR1A: 10}, "HTR1A", htr(10).voltage()},
+		{"HTR1B is resistance", fields{HTR1B: 10}, "HTR1B", htr(10).resistance()},
+		{"HTR1OD is voltage", fields{HTR1OD: 10}, "HTR1OD", htr(10).voltage()},
+		{"HTR2A is voltage", fields{HTR2A: 10}, "HTR2A", htr(10).voltage()},
+		{"HTR2B is resistance", fields{HTR2B: 10}, "HTR2B", htr(10).resistance()},
+		{"HTR2OD is voltage", fields{HTR2OD: 10}, "HTR2OD", htr(10).voltage()},
+		{"HTR3A is voltage", fields{HTR3A: 10}, "HTR3A", htr(10).voltage()},
+		{"HTR3B is resistance", fields{HTR3B: 10}, "HTR3B", htr(10).resistance()},
+		{"HTR3OD is voltage", fields{HTR3OD: 10}, "HTR3OD", htr(10).voltage()},
+		{"HTR4A is voltage", fields{HTR4A: 10}, "HTR4A", htr(10).voltage()},
+		{"HTR4B is resistance", fields{HTR4B: 10}, "HTR4B", htr(10).resistance()},
+		{"HTR4OD is voltage", fields{HTR4OD: 10}, "HTR4OD", htr(10).voltage()},
+		{"HTR5A is voltage", fields{HTR5A: 10}, "HTR5A", htr(10).voltage()},
+		{"HTR5B is resistance", fields{HTR5B: 10}, "HTR5B", htr(10).resistance()},
+		{"HTR5OD is voltage", fields{HTR5OD: 10}, "HTR5OD", htr(10).voltage()},
+		{"HTR6A is voltage", fields{HTR6A: 10}, "HTR6A", htr(10).voltage()},
+		{"HTR6B is resistance", fields{HTR6B: 10}, "HTR6B", htr(10).resistance()},
+		{"HTR6OD is voltage", fields{HTR6OD: 10}, "HTR6OD", htr(10).voltage()},
+		{"HTR7A is voltage", fields{HTR7A: 10}, "HTR7A", htr(10).voltage()},
+		{"HTR7B is resistance", fields{HTR7B: 10}, "HTR7B", htr(10).resistance()},
+		{"HTR7OD is voltage", fields{HTR7OD: 10}, "HTR7OD", htr(10).voltage()},
+		{"HTR8A is voltage", fields{HTR8A: 10}, "HTR8A", htr(10).voltage()},
+		{"HTR8B is resistance", fields{HTR8B: 10}, "HTR8B", htr(10).resistance()},
+		{"HTR8OD is voltage", fields{HTR8OD: 10}, "HTR8OD", htr(10).voltage()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			htr := &HTR{
+				HTR1A:  tt.fields.HTR1A,
+				HTR1B:  tt.fields.HTR1B,
+				HTR1OD: tt.fields.HTR1OD,
+				HTR2A:  tt.fields.HTR2A,
+				HTR2B:  tt.fields.HTR2B,
+				HTR2OD: tt.fields.HTR2OD,
+				HTR3A:  tt.fields.HTR3A,
+				HTR3B:  tt.fields.HTR3B,
+				HTR3OD: tt.fields.HTR3OD,
+				HTR4A:  tt.fields.HTR4A,
+				HTR4B:  tt.fields.HTR4B,
+				HTR4OD: tt.fields.HTR4OD,
+				HTR5A:  tt.fields.HTR5A,
+				HTR5B:  tt.fields.HTR5B,
+				HTR5OD: tt.fields.HTR5OD,
+				HTR6A:  tt.fields.HTR6A,
+				HTR6B:  tt.fields.HTR6B,
+				HTR6OD: tt.fields.HTR6OD,
+				HTR7A:  tt.fields.HTR7A,
+				HTR7B:  tt.fields.HTR7B,
+				HTR7OD: tt.fields.HTR7OD,
+				HTR8A:  tt.fields.HTR8A,
+				HTR8B:  tt.fields.HTR8B,
+				HTR8OD: tt.fields.HTR8OD,
+			}
+			report := htr.Report()
+			value := reflect.ValueOf(report)
+			field := reflect.Indirect(value).FieldByName(tt.field)
+			if got := field.Float(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("HTR.Report() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/aez/power.go
+++ b/internal/aez/power.go
@@ -18,7 +18,39 @@ type PWR struct {
 	PWRP3C3 uint16 // +3V3 current sense 0..4095
 }
 
+//PWRReport structure in useful units
+type PWRReport struct {
+	PWRT    float64 // Temp. sense voltage
+	PWRP32V float64 // +32V voltage sense voltage
+	PWRP32C float64 // +32V current sense current
+	PWRP16V float64 // +16V voltage sense voltage
+	PWRP16C float64 // +16V current sense current
+	PWRM16V float64 // -16V voltage sense voltage
+	PWRM16C float64 // -16V current sense current
+	PWRP3V3 float64 // +3V3 voltage sense voltage
+	PWRP3C3 float64 // +3V3 current sense current
+}
+
 // Read PWR
 func (pwr *PWR) Read(buf io.Reader) error {
 	return binary.Read(buf, binary.BigEndian, pwr)
+}
+
+func pwrVoltageADC(data uint16) float64 {
+	return voltageConstant * float64(data)
+}
+
+// Report returns a PWRReport with useful units
+func (pwr *PWR) Report() PWRReport {
+	return PWRReport{
+		PWRT:    pwrVoltageADC(pwr.PWRT),
+		PWRP32V: 21 * pwrVoltageADC(pwr.PWRP32V),
+		PWRP16V: 11 * pwrVoltageADC(pwr.PWRP16V),
+		PWRM16V: -10 * pwrVoltageADC(pwr.PWRM16V),
+		PWRP3V3: 4 * pwrVoltageADC(pwr.PWRP3V3),
+		PWRP32C: 10.1 / 100 * pwrVoltageADC(pwr.PWRP32C),
+		PWRP16C: 10.1 / 5 * pwrVoltageADC(pwr.PWRP16C),
+		PWRM16C: 10.1 / 100 * pwrVoltageADC(pwr.PWRM16C),
+		PWRP3C3: 10.1 / 20 * pwrVoltageADC(pwr.PWRP3C3),
+	}
 }

--- a/internal/aez/power.go
+++ b/internal/aez/power.go
@@ -5,22 +5,86 @@ import (
 	"io"
 )
 
+type pwr uint16
+
+func (data pwr) voltageADC() float64 {
+	return voltageConstant * float64(data)
+}
+
+type pwrt pwr
+
+func (data pwrt) voltage() float64 {
+	return pwr(data).voltageADC()
+}
+
+func (data pwrt) resistance() float64 {
+	return 3300/data.voltage() - 1000
+}
+
+type pwrp32v pwr
+
+func (data pwrp32v) voltage() float64 {
+	return 21 * pwr(data).voltageADC()
+}
+
+type pwrp32c pwr
+
+func (data pwrp32c) current() float64 {
+	return 10.1 / 100 * pwr(data).voltageADC()
+}
+
+type pwrp16v pwr
+
+func (data pwrp16v) voltage() float64 {
+	return 11 * pwr(data).voltageADC()
+}
+
+type pwrp16c pwr
+
+func (data pwrp16c) current() float64 {
+	return 10.1 / 5 * pwr(data).voltageADC()
+}
+
+type pwrm16v pwr
+
+func (data pwrm16v) voltage() float64 {
+	return -10 * pwr(data).voltageADC()
+}
+
+type pwrm16c pwr
+
+func (data pwrm16c) current() float64 {
+	return 10.1 / 100 * pwr(data).voltageADC()
+}
+
+type pwrp3v3 pwr
+
+func (data pwrp3v3) voltage() float64 {
+	return 4 * pwr(data).voltageADC()
+}
+
+type pwrp3c3 pwr
+
+func (data pwrp3c3) current() float64 {
+	return 10.1 / 20 * pwr(data).voltageADC()
+}
+
 //PWR structure 18 octext
 type PWR struct {
-	PWRT    uint16 // Temp. sense 0..4095
-	PWRP32V uint16 // +32V voltage sense 0..4095
-	PWRP32C uint16 // +32V current sense 0..4095
-	PWRP16V uint16 // +16V voltage sense 0..4095
-	PWRP16C uint16 // +16V current sense 0..4095
-	PWRM16V uint16 // -16V voltage sense 0..4095
-	PWRM16C uint16 // -16V current sense 0..4095
-	PWRP3V3 uint16 // +3V3 voltage sense 0..4095
-	PWRP3C3 uint16 // +3V3 current sense 0..4095
+	PWRT    pwrt    // Temp. sense 0..4095
+	PWRP32V pwrp32v // +32V voltage sense 0..4095
+	PWRP32C pwrp32c // +32V current sense 0..4095
+	PWRP16V pwrp16v // +16V voltage sense 0..4095
+	PWRP16C pwrp16c // +16V current sense 0..4095
+	PWRM16V pwrm16v // -16V voltage sense 0..4095
+	PWRM16C pwrm16c // -16V current sense 0..4095
+	PWRP3V3 pwrp3v3 // +3V3 voltage sense 0..4095
+	PWRP3C3 pwrp3c3 // +3V3 current sense 0..4095
 }
 
 //PWRReport structure in useful units
 type PWRReport struct {
-	PWRT    float64 // Temp. sense voltage
+	PWRT    float64 // Temp. sense resistance
 	PWRP32V float64 // +32V voltage sense voltage
 	PWRP32C float64 // +32V current sense current
 	PWRP16V float64 // +16V voltage sense voltage
@@ -43,14 +107,14 @@ func pwrVoltageADC(data uint16) float64 {
 // Report returns a PWRReport with useful units
 func (pwr *PWR) Report() PWRReport {
 	return PWRReport{
-		PWRT:    pwrVoltageADC(pwr.PWRT),
-		PWRP32V: 21 * pwrVoltageADC(pwr.PWRP32V),
-		PWRP16V: 11 * pwrVoltageADC(pwr.PWRP16V),
-		PWRM16V: -10 * pwrVoltageADC(pwr.PWRM16V),
-		PWRP3V3: 4 * pwrVoltageADC(pwr.PWRP3V3),
-		PWRP32C: 10.1 / 100 * pwrVoltageADC(pwr.PWRP32C),
-		PWRP16C: 10.1 / 5 * pwrVoltageADC(pwr.PWRP16C),
-		PWRM16C: 10.1 / 100 * pwrVoltageADC(pwr.PWRM16C),
-		PWRP3C3: 10.1 / 20 * pwrVoltageADC(pwr.PWRP3C3),
+		PWRT:    pwr.PWRT.resistance(),
+		PWRP32V: pwr.PWRP32V.voltage(),
+		PWRP32C: pwr.PWRP32C.current(),
+		PWRP16V: pwr.PWRP16V.voltage(),
+		PWRP16C: pwr.PWRP16C.current(),
+		PWRM16V: pwr.PWRM16V.voltage(),
+		PWRM16C: pwr.PWRM16C.current(),
+		PWRP3V3: pwr.PWRP3V3.voltage(),
+		PWRP3C3: pwr.PWRP3C3.current(),
 	}
 }

--- a/internal/aez/power.go
+++ b/internal/aez/power.go
@@ -18,7 +18,7 @@ func (data pwrt) voltage() float64 {
 }
 
 func (data pwrt) resistance() float64 {
-	return 3300/data.voltage() - 1000
+	return 3.3*1000/data.voltage() - 1000
 }
 
 type pwrp32v pwr

--- a/internal/aez/power_test.go
+++ b/internal/aez/power_test.go
@@ -1,0 +1,57 @@
+package aez
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPWR_Report(t *testing.T) {
+	type fields struct {
+		PWRT    pwrt
+		PWRP32V pwrp32v
+		PWRP32C pwrp32c
+		PWRP16V pwrp16v
+		PWRP16C pwrp16c
+		PWRM16V pwrm16v
+		PWRM16C pwrm16c
+		PWRP3V3 pwrp3v3
+		PWRP3C3 pwrp3c3
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		field  string
+		want   float64
+	}{
+		{"PWRT is resistance", fields{PWRT: 10}, "PWRT", pwrt(10).resistance()},
+		{"PWRP32V is voltage", fields{PWRP32V: 10}, "PWRP32V", pwrp32v(10).voltage()},
+		{"PWRP32C is current", fields{PWRP32C: 10}, "PWRP32C", pwrp32c(10).current()},
+		{"PWRP16V is voltage", fields{PWRP16V: 10}, "PWRP16V", pwrp16v(10).voltage()},
+		{"PWRP16C is current", fields{PWRP16C: 10}, "PWRP16C", pwrp16c(10).current()},
+		{"PWRM16V is voltage", fields{PWRM16V: 10}, "PWRM16V", pwrm16v(10).voltage()},
+		{"PWRM16C is current", fields{PWRM16C: 10}, "PWRM16C", pwrm16c(10).current()},
+		{"PWRP3V3 is voltage", fields{PWRP3V3: 10}, "PWRP3V3", pwrp3v3(10).voltage()},
+		{"PWRP3C3 is current", fields{PWRP3C3: 10}, "PWRP3C3", pwrp3c3(10).current()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pwr := &PWR{
+				PWRT:    tt.fields.PWRT,
+				PWRP32V: tt.fields.PWRP32V,
+				PWRP32C: tt.fields.PWRP32C,
+				PWRP16V: tt.fields.PWRP16V,
+				PWRP16C: tt.fields.PWRP16C,
+				PWRM16V: tt.fields.PWRM16V,
+				PWRM16C: tt.fields.PWRM16C,
+				PWRP3V3: tt.fields.PWRP3V3,
+				PWRP3C3: tt.fields.PWRP3C3,
+			}
+			report := pwr.Report()
+			value := reflect.ValueOf(report)
+			field := reflect.Indirect(value).FieldByName(tt.field)
+			if got := field.Float(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PWR.Report() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is a partial feature, it uses equations in AEZICD002 to translate various primary read/encoded data into physical units.

It was a bit vague in the case of the HTR struct what unit will be suitable for HTRxA and HTRxOD:

> Each regulator has two sensors, one used for regulation (HTRxA) and one for measuring the temperature
> (HTRxB). Along with these, the output drive value is also returned (HTRxOD).

So I left those as voltages, while I transformed HTRxB to resistance, which seems one step closer to temperature (if I've understood everything correctly).

For CPRUA/CPRUB (called CPRU), I ended at voltage as that is as far as equations in the spec take it.

For PWR I made PWRT into resistance, the other PWxV I left as voltage while the PWxC I left as currents as this seemed to be according to the specification.

I didn't do reports for any other struct yet (e.g. converting modes to strings)

Resolves #8 (will make explicit issue of producing temperature)