### PR TITLE
Nicer interface for cli.go

### DIFF
--- a/internal/aez/general.go
+++ b/internal/aez/general.go
@@ -8,6 +8,26 @@ import (
 	"github.com/innosat-mats/rac-extract-payload/internal/ccsds"
 )
 
+// SID is the id of a single housekeeping parameter
+type SID uint16
+
+// SIDSTAT is the SID of STAT.
+//
+// SIDHTR is the SID of HTR.
+//
+// SIDPWR is the SID of PWR.
+//
+// SIDCPRUA is the SID of CPRUA.
+//
+// SIDCPRUB is the SID of CPRUB.
+const (
+	SIDSTAT  SID = 1
+	SIDHTR   SID = 10
+	SIDPWR   SID = 20
+	SIDCPRUA SID = 30
+	SIDCPRUB SID = 31
+)
+
 //STAT General status housekeeping report of the payload instrument.
 type STAT struct { //(34 octets)
 	SPID   uint16 // Software Part ID

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -63,7 +63,7 @@ func main() {
 			log.Fatal("checksum bad")
 		}
 
-		if header.Type() != 1 {
+		if header.Type() != innosat.TC {
 			// Telecommands not supported yet
 			continue
 		}
@@ -74,38 +74,38 @@ func main() {
 			log.Fatal(err)
 		}
 
-		if header.Type() == 1 && header.APID() == 100 && dataHeader.ServiceType == 3 && dataHeader.ServiceSubType == 25 {
-			var sid uint16
+		if header.Type() == innosat.TM && header.IsMainApplication() && dataHeader.IsHousekeeping() {
+			var sid aez.SID
 			binary.Read(reader, binary.BigEndian, &sid)
-			if sid == 1 {
+			if sid == aez.SIDSTAT {
 				stat := aez.STAT{}
 				err = stat.Read(reader)
 				if err != nil {
 					log.Fatal("stat", err)
 				}
 			}
-			if sid == 10 {
+			if sid == aez.SIDHTR {
 				htr := aez.HTR{}
 				err = htr.Read(reader)
 				if err != nil {
 					log.Fatal("htr", err)
 				}
 			}
-			if sid == 20 {
+			if sid == aez.SIDPWR {
 				pwr := aez.PWR{}
 				err = pwr.Read(reader)
 				if err != nil {
 					log.Fatal("pwr", err)
 				}
 			}
-			if sid == 30 {
+			if sid == aez.SIDCPRUA {
 				cprua := aez.CPRU{}
 				err = cprua.Read(reader)
 				if err != nil {
 					log.Fatal("cprua", err)
 				}
 			}
-			if sid == 31 {
+			if sid == aez.SIDCPRUB {
 				cprub := aez.CPRU{}
 				err = cprub.Read(reader)
 				if err != nil {

--- a/internal/cli/rac_package_test.go
+++ b/internal/cli/rac_package_test.go
@@ -71,7 +71,7 @@ func Example() {
 			log.Fatal("checksum bad")
 		}
 
-		fmt.Println(header.APID())
+		fmt.Println(header.IsMainApplication())
 
 		dataHeader := innosat.TMDataFieldHeader{}
 		err = dataHeader.Read(reader)
@@ -79,7 +79,7 @@ func Example() {
 			log.Fatal(err)
 		}
 
-		if header.APID() == 100 && dataHeader.ServiceType == 3 && dataHeader.ServiceSubType == 25 {
+		if header.IsMainApplication() && dataHeader.IsHousekeeping() {
 			var sid uint16
 			binary.Read(reader, binary.BigEndian, &sid)
 			if sid == 1 {
@@ -94,6 +94,6 @@ func Example() {
 	}
 	// Output:
 	// 2019-03-01 15:07:59.7 +0000 UTC
-	// 100
+	// true
 	// {32516 2 33284 2 2485518336 4761 2 0 0 50331648 1811939328 419430400}
 }

--- a/internal/innosat/source.go
+++ b/internal/innosat/source.go
@@ -12,8 +12,8 @@ type SourcePacketHeaderType uint
 //
 //TC is the source package type for telecommand
 const (
-	TM SourcePacketHeaderType = 0
-	TC SourcePacketHeaderType = 1
+	TC SourcePacketHeaderType = 0
+	TM SourcePacketHeaderType = 1
 )
 
 //SourcePacketHeader Source Packet Header

--- a/internal/innosat/source.go
+++ b/internal/innosat/source.go
@@ -5,6 +5,17 @@ import (
 	"io"
 )
 
+//SourcePacketHeaderType is the type of the source packet (TM/TC)
+type SourcePacketHeaderType uint
+
+//TM is the source package type for telemetry
+//
+//TC is the source package type for telecommand
+const (
+	TM SourcePacketHeaderType = 0
+	TC SourcePacketHeaderType = 1
+)
+
 //SourcePacketHeader Source Packet Header
 type SourcePacketHeader struct {
 	PacketID              uint16
@@ -22,9 +33,9 @@ func (sph *SourcePacketHeader) Version() uint {
 	return uint(sph.PacketID >> 13)
 }
 
-// Type ...
-func (sph *SourcePacketHeader) Type() uint {
-	return uint((sph.PacketID << 3) >> 15)
+// Type is either Telecommand or Telemetry
+func (sph *SourcePacketHeader) Type() SourcePacketHeaderType {
+	return SourcePacketHeaderType((sph.PacketID << 3) >> 15)
 }
 
 // HeaderType ...
@@ -32,9 +43,13 @@ func (sph *SourcePacketHeader) HeaderType() uint {
 	return uint((sph.PacketID << 4) >> 15)
 }
 
-// APID ...
-func (sph *SourcePacketHeader) APID() uint16 {
+func (sph *SourcePacketHeader) apid() uint16 {
 	return (sph.PacketID << 5) >> 5
+}
+
+// IsMainApplication says if packet is for main application
+func (sph *SourcePacketHeader) IsMainApplication() bool {
+	return sph.apid() == 100
 }
 
 // GroupingFlags ...

--- a/internal/innosat/source_test.go
+++ b/internal/innosat/source_test.go
@@ -23,7 +23,7 @@ func TestType(t *testing.T) {
 		0}
 
 	ans := sph.Type()
-	if ans != TC {
+	if ans != TM {
 		t.Errorf("Type() = %b; want 1", ans)
 	}
 }

--- a/internal/innosat/source_test.go
+++ b/internal/innosat/source_test.go
@@ -23,7 +23,7 @@ func TestType(t *testing.T) {
 		0}
 
 	ans := sph.Type()
-	if ans != 1 {
+	if ans != TC {
 		t.Errorf("Type() = %b; want 1", ans)
 	}
 }
@@ -36,18 +36,6 @@ func TestHeaderType(t *testing.T) {
 	ans := sph.HeaderType()
 	if ans != 1 {
 		t.Errorf("HeaderType() = %b; want 1", ans)
-	}
-}
-
-func TestAPID(t *testing.T) {
-	sph := SourcePacketHeader{
-		0b0000011111111111,
-		0,
-		0}
-
-	ans := sph.APID()
-	if ans != 0b11111111111 {
-		t.Errorf("APID() = %b; want 11111111111", ans)
 	}
 }
 
@@ -72,5 +60,33 @@ func TestSequenceCount(t *testing.T) {
 	ans := sph.SequenceCount()
 	if ans != 0b11111111111111 {
 		t.Errorf("SequenceCount() = %02b; want 11111111111111", ans)
+	}
+}
+
+func TestSourcePacketHeader_IsMainApplication(t *testing.T) {
+	type fields struct {
+		PacketID              uint16
+		PacketSequenceControl uint16
+		PacketLength          uint16
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{"Returns false when apid not 100", fields{}, false},
+		{"Returns true when apid is 100", fields{PacketID: 0b1100110011000000}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sph := &SourcePacketHeader{
+				PacketID:              tt.fields.PacketID,
+				PacketSequenceControl: tt.fields.PacketSequenceControl,
+				PacketLength:          tt.fields.PacketLength,
+			}
+			if got := sph.IsMainApplication(); got != tt.want {
+				t.Errorf("SourcePacketHeader.IsMainApplication() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/innosat/telemetry.go
+++ b/internal/innosat/telemetry.go
@@ -36,3 +36,8 @@ func (tmdfh *TMDataFieldHeader) Time(epoch time.Time) time.Time {
 func (tmdfh *TMDataFieldHeader) Nanoseconds() int64 {
 	return ccsds.UnsegmentedTimeNanoseconds(tmdfh.CUCTimeSeconds, tmdfh.CUCTimeFraction)
 }
+
+// IsHousekeeping returns if payload contains housekeeping data
+func (tmdfh *TMDataFieldHeader) IsHousekeeping() bool {
+	return tmdfh.ServiceType == 3 && tmdfh.ServiceSubType == 25
+}

--- a/internal/innosat/telemetry_test.go
+++ b/internal/innosat/telemetry_test.go
@@ -106,3 +106,41 @@ func TestTMDataFieldHeader_Nanoseconds(t *testing.T) {
 		})
 	}
 }
+
+func TestTMDataFieldHeader_IsHousekeeping(t *testing.T) {
+	type fields struct {
+		PUS             uint8
+		ServiceType     uint8
+		ServiceSubType  uint8
+		CUCTimeSeconds  uint32
+		CUCTimeFraction uint16
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{"False in general", fields{}, false},
+		{"False if only correct ServiceType", fields{ServiceType: 3}, false},
+		{"False if only correct ServiceSubType", fields{ServiceSubType: 25}, false},
+		{
+			"True if correct ServiceType and ServiceSubType",
+			fields{ServiceType: 3, ServiceSubType: 25},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmdfh := &TMDataFieldHeader{
+				PUS:             tt.fields.PUS,
+				ServiceType:     tt.fields.ServiceType,
+				ServiceSubType:  tt.fields.ServiceSubType,
+				CUCTimeSeconds:  tt.fields.CUCTimeSeconds,
+				CUCTimeFraction: tt.fields.CUCTimeFraction,
+			}
+			if got := tmdfh.IsHousekeeping(); got != tt.want {
+				t.Errorf("TMDataFieldHeader.IsHousekeeping() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Was a bit unsure maybe we should have names like `SID_PWR` but go doesn't seem to appreciate underscores.
* I updated `cli.go` so it makes sense with regards to TC and TM, which means it won't process anything in the racs since they don't seem to follow the specs. But I rather have our code make sense and then if one wants to use the cli while developing just comment  out the check or flip between the two.

Resolves #5
Resolves #4 (all that were in use at least, rest can be dealt with when we use them)