### PR TITLE
A first real CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ BIN_DIR=bin
 all: test build
 build:
 		$(GOBUILD) -o $(BIN_DIR) -v ./...
-		mv ${BIN_DIR}/cli ${BIN_DIR}/rac
 test:
 		$(GOTEST) -v ./...
 clean:

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,10 @@ BIN_DIR=bin
 
 
 all: test build
-build: 
+build:
 		$(GOBUILD) -o $(BIN_DIR) -v ./...
-test: 
+		mv ${BIN_DIR}/cli ${BIN_DIR}/rac
+test:
 		$(GOTEST) -v ./...
-clean: 
+clean:
 		$(GOCLEAN)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"errors"
+	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"time"
@@ -9,27 +12,115 @@ import (
 	"github.com/innosat-mats/rac-extract-payload/internal/common"
 )
 
-func callback(pkg common.DataRecord) {
-	fmt.Println(pkg)
+func generateDiskWriterCallback(
+	output string,
+	writeImages bool,
+	writeTimeseries bool,
+) common.ExtractCallback {
+	return func(pkg common.DataRecord) {
+		// This is just a placeholder, should write to output directory
+	}
 }
 
-func main() {
-	batch := make([]common.StreamBatch, len(os.Args)-1)
-	for n, filename := range os.Args[1:] {
+func generateStdoutCallback(
+	out io.Writer,
+	writeTimeseries bool,
+) common.ExtractCallback {
+
+	return func(pkg common.DataRecord) {
+		if writeTimeseries {
+			fmt.Fprintf(out, "%+v\n", pkg)
+		}
+	}
+}
+
+var skipImages *bool
+var skipTimeseries *bool
+var outputDirectory *string
+var stdout *bool
+
+//myUsage replaces default usage since it doesn't include information on non-flags
+func myUsage() {
+	fmt.Println("Extracts information from Innosat-MATS rac-files")
+	fmt.Println()
+	fmt.Printf("Usage: %s [OPTIONS] rac-file ...\n", os.Args[0])
+	fmt.Println()
+	flag.PrintDefaults()
+}
+
+func getCallback(
+	stdout bool,
+	outputDirectory string,
+	skipImages bool,
+	skipTimeseries bool,
+) (common.ExtractCallback, error) {
+	if outputDirectory == "" && !stdout {
+		flag.Usage()
+		fmt.Println("\nExpected an output directory")
+		return nil, errors.New("Invalid arguments")
+	}
+	if skipTimeseries && (skipImages || stdout) {
+		fmt.Println("Nothing will be extracted, only validating integrity of rac-file(s)")
+	}
+
+	if stdout {
+		return generateStdoutCallback(os.Stdout, !skipTimeseries), nil
+	}
+	return generateDiskWriterCallback(
+		outputDirectory,
+		!skipImages,
+		!skipTimeseries,
+	), nil
+}
+
+func processFiles(
+	extractor common.ExtractFunction,
+	inputFiles []string,
+	callback common.ExtractCallback,
+) error {
+	batch := make([]common.StreamBatch, len(inputFiles))
+	for n, filename := range inputFiles {
 		f, err := os.Open(filename)
 		defer f.Close()
 		if err != nil {
-			log.Fatalln(err)
+			return err
 		}
 
 		batch[n] = common.StreamBatch{
 			Buf: f,
 			Origin: common.OriginDescription{
-				Name: filename,
-				Date: time.Now(),
+				Name:           filename,
+				ProcessingDate: time.Now(),
 			},
 		}
 
 	}
-	common.ExtractData(callback, batch...)
+	extractor(callback, batch...)
+	return nil
+}
+
+func init() {
+	skipImages = flag.Bool("skip-images", false, "Extract images from rac-files.\n(Default: false)")
+	skipTimeseries = flag.Bool("skip-timeseries", false, "Extract timeseries from rac-files.\n(Default: false)")
+	outputDirectory = flag.String("output", "", "Directory to place images and/or timeseries data")
+	stdout = flag.Bool("stdout", false, "Output to standard out instead of to disk (only timeseries)\n(Default: false)")
+	flag.Usage = myUsage
+}
+
+func main() {
+	flag.Parse()
+	inputFiles := flag.Args()
+	if len(inputFiles) == 0 {
+		flag.Usage()
+		fmt.Println("\nNo rac-files supplied")
+		os.Exit(1)
+	}
+	callback, err := getCallback(*stdout, *outputDirectory, *skipImages, *skipTimeseries)
+	if err != nil {
+		os.Exit(1)
+	}
+	err = processFiles(common.ExtractData, inputFiles, callback)
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/innosat-mats/rac-extract-payload/internal/common"
+)
+
+func Test_generateStdoutCallback(t *testing.T) {
+	type args struct {
+		writeTimeseries bool
+	}
+	type innerArgs struct {
+		dataRecord common.DataRecord
+	}
+	tests := []struct {
+		name      string
+		args      args
+		innerArgs innerArgs
+		want      string
+	}{
+		{"Prints nothing when not asked to", args{false}, innerArgs{common.DataRecord{}}, ""},
+		{
+			"Prints nothing when not asked to",
+			args{true},
+			innerArgs{common.DataRecord{}},
+			"{Origin:{Name: ProcessingDate:0001-01-01 00:00:00 +0000 UTC} RamsesHeader:{Synch:0 Length:0 Port:0 Type:0 Secure:0 Time:0 Date:0} RamsesSecure:{IPAddress:0 Port:0 Seq:0 Retransmission:0 Ack:0 _:0} SourceHeader:{PacketID:0 PacketSequenceControl:0 PacketLength:0} TMHeader:{PUS:0 ServiceType:0 ServiceSubType:0 CUCTimeSeconds:0 CUCTimeFraction:0} Data:<nil> Error:<nil> Buffer:[]}\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			callback := generateStdoutCallback(buf, tt.args.writeTimeseries)
+			callback(tt.innerArgs.dataRecord)
+			if got := buf.String(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("generateStdoutCallback() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getCallback(t *testing.T) {
+	type args struct {
+		stdout          bool
+		outputDirectory string
+		skipImages      bool
+		skipTimeseries  bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"Returns stdout callback", args{stdout: true}, false},
+		{"Returns disk callback", args{outputDirectory: "somewhere"}, false},
+		{"Returns error if no output directory", args{}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := getCallback(tt.args.stdout, tt.args.outputDirectory, tt.args.skipImages, tt.args.skipTimeseries)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getCallback() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func Test_processFiles(t *testing.T) {
+	type args struct {
+		inputFiles []string
+		callback   common.ExtractCallback
+	}
+	type fixtures struct {
+		files []string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		fixtures fixtures
+		wantErr  bool
+	}{
+		{
+			"Processes all files",
+			args{inputFiles: []string{"a", "b"}},
+			fixtures{files: []string{"a", "b", "c"}},
+			false,
+		},
+		{
+			"Fails on missing files",
+			args{inputFiles: []string{"a", "b"}},
+			fixtures{files: []string{}},
+			true,
+		},
+	}
+	mapFilenamesToDirectory := func(dir string, files []string) []string {
+		newFiles := make([]string, len(files))
+		for idx, file := range files {
+			newFiles[idx] = filepath.Join(dir, file)
+		}
+		return newFiles
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, err := ioutil.TempDir("/tmp", "mats-testing")
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer os.RemoveAll(dir)
+			for _, fileName := range tt.fixtures.files {
+				filePath := filepath.Join(dir, fileName)
+				file, err := os.Create(filePath)
+				if err != nil {
+					log.Fatal(err)
+				}
+				file.Close()
+			}
+			updatedFilenames := mapFilenamesToDirectory(dir, tt.args.inputFiles)
+			extractor := func(callback common.ExtractCallback, streamBatch ...common.StreamBatch) {
+				ptCallback := reflect.ValueOf(callback).Pointer()
+				ptArgsCallback := reflect.ValueOf(tt.args.callback).Pointer()
+				if ptCallback != ptArgsCallback {
+					t.Errorf("Expected callback to be passed on to extractor, got %v", callback)
+				}
+
+				if len(streamBatch) != len(tt.args.inputFiles) {
+					t.Errorf("Expected %v streams but got %v", len(tt.args.inputFiles), len(streamBatch))
+				}
+				for idx, stream := range streamBatch {
+					if stream.Buf == nil {
+						t.Errorf("Expected stream %v to have a buffer but got nil", idx)
+					}
+					if stream.Origin.Name != updatedFilenames[idx] {
+						t.Errorf(
+							"Expected stream %v to have Name %v but got %v",
+							idx,
+							updatedFilenames[idx],
+							stream.Origin.Name,
+						)
+					}
+					elapsed := time.Now().Sub(stream.Origin.ProcessingDate)
+					if elapsed < 0 || elapsed > time.Second {
+						t.Errorf("Processing time %v seems not to be now", stream.Origin.ProcessingDate)
+					}
+				}
+			}
+
+			err = processFiles(
+				extractor,
+				updatedFilenames,
+				tt.args.callback,
+			)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getCallback() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/internal/common/extract_data.go
+++ b/internal/common/extract_data.go
@@ -4,8 +4,14 @@ import (
 	"sync"
 )
 
+// ExtractCallback is the type of the callback function
+type ExtractCallback func(data DataRecord)
+
+// ExtractFunction is the type of the ExtractData function
+type ExtractFunction func(callback ExtractCallback, streamBatch ...StreamBatch)
+
 // ExtractData reads Ramses data packages and extract the instrument data.
-func ExtractData(callback func(data DataRecord), streamBatch ...StreamBatch) {
+func ExtractData(callback ExtractCallback, streamBatch ...StreamBatch) {
 	var waitGroup sync.WaitGroup
 	ramsesChannel := make(chan DataRecord)
 	innosatChannel := make(chan DataRecord)

--- a/internal/common/origin.go
+++ b/internal/common/origin.go
@@ -4,6 +4,6 @@ import "time"
 
 // OriginDescription describes the origin of ramses packages
 type OriginDescription struct {
-	Name string    // Name of the batch or file
-	Date time.Time // Runtime of the batch
+	Name           string    // Name of the batch or file
+	ProcessingDate time.Time // Runtime of the batch
 }


### PR DESCRIPTION
# Interface
```
$ ./bin/rac 
Extracts information from Innosat-MATS rac-files

Usage: ./bin/rac [OPTIONS] rac-file ...

  -output string
    	Directory to place images and/or timeseries data
  -skip-images
    	Extract images from rac-files.
    	(Default: false)
  -skip-timeseries
    	Extract timeseries from rac-files.
    	(Default: false)
  -stdout
    	Output to standard out instead of to disk (only timeseries)
    	(Default: false)

No rac-files supplied
```

# Features
* Allows writing to standard out or disk (not really implemented yet).
* If disk, then requires `-output`
* If both `-skip-images` and `-skip-timeseries` then it just runs through silently without any output as ways to validate files

# Testing
It was difficult testing some aspects of this so:
* `main` is untested but kept minimal
* `getCallback` can't really test which type of callback is gotten nor how arguments were passed to the respective callback factories.
* some other holes, like what is usage printed and a bit vague test on the setting of processing time

Resolves #25 