### PR TITLE
Jpeg rowstride

### DIFF
--- a/internal/decodejpeg/decode.c
+++ b/internal/decodejpeg/decode.c
@@ -21,7 +21,8 @@ read_JPEG_file(char *inbuffer, size_t size)
   (void)jpeg_read_header(&cinfo, TRUE);
 
   (void)jpeg_start_decompress(&cinfo);
-  result.pix = (char *)malloc(cinfo.output_height * cinfo.output_width * cinfo.output_components * (BYTES_PER_SAMPLE+1));
+  result.pix = (char *)malloc(cinfo.output_height * cinfo.output_width
+                              * cinfo.output_components * BYTES_PER_SAMPLE);
   result.width = cinfo.output_width;
   result.height = cinfo.output_height;
 
@@ -31,7 +32,9 @@ read_JPEG_file(char *inbuffer, size_t size)
   while (cinfo.output_scanline < cinfo.output_height)
   {
     (void)jpeg_read_scanlines(&cinfo, buffer, 1);
-    memcpy(&(result.pix)[(cinfo.output_scanline - 1) * row_stride], buffer[0], row_stride * BYTES_PER_SAMPLE);
+    memcpy(&(result.pix)[(cinfo.output_scanline - 1) * row_stride],
+           buffer[0],
+           row_stride * BYTES_PER_SAMPLE);
   }
   (void)jpeg_finish_decompress(&cinfo);
 

--- a/internal/decodejpeg/decode.c
+++ b/internal/decodejpeg/decode.c
@@ -34,7 +34,7 @@ read_JPEG_file(char *inbuffer, size_t size)
     (void)jpeg_read_scanlines(&cinfo, buffer, 1);
     memcpy(&(result.pix)[(cinfo.output_scanline - 1) * row_stride],
            buffer[0],
-           row_stride * BYTES_PER_SAMPLE);
+           row_stride);
   }
   (void)jpeg_finish_decompress(&cinfo);
 

--- a/internal/decodejpeg/decode_test.go
+++ b/internal/decodejpeg/decode_test.go
@@ -18,7 +18,7 @@ func Example() {
 		log.Fatalln(err)
 	}
 	raw, width, height, err := JpegImageData(fileContents)
-	// repeated us is OK
+	// repeated use is OK
 	raw, width, height, err = JpegImageData(fileContents)
 	bufArray := []byte{}
 	buf := bytes.NewBuffer(bufArray)


### PR DESCRIPTION
Revert @joakimmoller's quick fix and instead change chunk size in `memcpy`. It was set to `rowstride * BYTES_IN SAMPLE` but should - as I understand it - just be a single row, that is to say just `rowstride`. The fix is in the second commit. The first commit fixes annoyingly long lines in the `c` code.