### PR TITLE
Fail execution if interpolation tables are wrong

### DIFF
--- a/internal/aez/interpolate.go
+++ b/internal/aez/interpolate.go
@@ -2,6 +2,7 @@ package aez
 
 import (
 	"fmt"
+	"log"
 )
 
 // ErrXTooLarge x value sent to interpolator is too large
@@ -32,34 +33,6 @@ func (err ErrXTooSmall) Error() string {
 	)
 }
 
-// ErrXYTooShort x or y slice sent to interpolator is too short
-type ErrXYTooShort int
-
-func (err ErrXYTooShort) String() string {
-	return fmt.Sprint(int(err))
-}
-
-func (err ErrXYTooShort) Error() string {
-	return fmt.Sprintf(
-		"Slices x and y must be at least of length 2 (%d < 0). Returning -9999.",
-		int(err),
-	)
-}
-
-// ErrXYMismatch x and y slices of different lengths
-type ErrXYMismatch struct{ lenRes, lenTemp int }
-
-func (err ErrXYMismatch) String() string {
-	return fmt.Sprintf("%d, %d", err.lenRes, err.lenTemp)
-}
-
-func (err ErrXYMismatch) Error() string {
-	return fmt.Sprintf(
-		"Slices x and y not of same length (%d != %d). Returning absolute -9999.",
-		err.lenRes, err.lenTemp,
-	)
-}
-
 // Note! Assumes xSlice contains a monotonically increasing values!
 func getXIndex(x float64, xSlice []float64) int {
 	var i int
@@ -78,12 +51,16 @@ func Interpolate(
 	x float64, xSlice []float64, ySlice []float64,
 ) (float64, error) {
 	if len(xSlice) != len(ySlice) {
-		return -9999, ErrXYMismatch{
+		log.Fatalf(
+			"Slices x and y not of same length (%d != %d).\n",
 			len(xSlice), len(ySlice),
-		}
+		)
 	}
 	if len(xSlice) < 2 {
-		return -9999, ErrXYTooShort(len(xSlice))
+		log.Fatalf(
+			"Slices x and y must be at least of length 2 (%d < 2).\n",
+			len(xSlice),
+		)
 	}
 
 	i := getXIndex(x, xSlice)

--- a/internal/aez/interpolate_test.go
+++ b/internal/aez/interpolate_test.go
@@ -100,18 +100,6 @@ func Test_Interpolate(t *testing.T) {
 			155,
 			true,
 		},
-		{
-			"Interpolate gets angry if resistances and temperatures of different size",
-			args{0, htrResistances[:], pwrTemperatures[:]},
-			-9999,
-			true,
-		},
-		{
-			"Interpolate gets angry if x or y slice too short",
-			args{0, []float64{1}, []float64{0}},
-			-9999,
-			true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Make execution stop if tables are wrong (too short or different lengths), instead of raising an error. The only time this could occur, is if we've done something wrong in our implementation, and that will be easier to catch if the execution stops. In the current implementation, the database would be flooded uselessly with -9999, that we would have to manually remove...