### PR TITLE
Output JSON per jpeg

### DIFF
--- a/internal/aez/general.go
+++ b/internal/aez/general.go
@@ -2,6 +2,7 @@ package aez
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"io"
 	"reflect"
@@ -46,6 +47,11 @@ func (sid SID) String() string {
 	default:
 		return fmt.Sprintf("Unknown SID: %v", int(sid))
 	}
+}
+
+// MarshalJSON makes a custom json of what is of interest in the struct
+func (sid *SID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(sid.String())
 }
 
 // RID is Report Identification
@@ -93,6 +99,11 @@ func (rid RID) String() string {
 	default:
 		return fmt.Sprintf("Unknown RID: %v", int(rid))
 	}
+}
+
+// MarshalJSON makes a custom json of what is of interest in the struct
+func (rid *RID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(rid.String())
 }
 
 //STAT General status housekeeping report of the payload instrument.

--- a/internal/aez/general_test.go
+++ b/internal/aez/general_test.go
@@ -358,3 +358,59 @@ func TestRID_String(t *testing.T) {
 		})
 	}
 }
+
+func TestRID_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		rid     RID
+		want    []byte
+		wantErr bool
+	}{
+		{
+			"Marschals into string representation",
+			CCD2,
+			[]byte("\"CCD2\""),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.rid.MarshalJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RID.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RID.MarshalJSON() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSID_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		sid     SID
+		want    []byte
+		wantErr bool
+	}{
+		{
+			"Marschals into string representation",
+			SIDHTR,
+			[]byte("\"HTR\""),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.sid.MarshalJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SID.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SID.MarshalJSON() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/common/datarecord.go
+++ b/internal/common/datarecord.go
@@ -15,9 +15,9 @@ type DataRecord struct {
 	TMHeader     innosat.TMDataFieldHeader  `json:"tmHeader"`     // Data header information
 	SID          aez.SID                    // SID of the Data if any
 	RID          aez.RID                    // RID of Data if any
-	Data         Exportable                 `json:"data"`  // The data payload itself, HK report, jpeg image etc.
-	Error        error                      `json:"error"` // First propagated error from the decoding process
-	Buffer       []byte                     `json:"-"`     // Currently unprocessed data (payload)
+	Data         Exportable                 `json:"data"`            // The data payload itself, HK report, jpeg image etc.
+	Error        error                      `json:"error,omitempty"` // First propagated error from the decoding process
+	Buffer       []byte                     `json:"-"`               // Currently unprocessed data (payload)
 }
 
 // CSVSpecifications returns specifications used to generate content in CSV compatible format

--- a/internal/common/datarecord.go
+++ b/internal/common/datarecord.go
@@ -8,16 +8,16 @@ import (
 
 // DataRecord holds the full decode from one or many Ramses packages
 type DataRecord struct {
-	Origin       OriginDescription          // Describes the origin of the data like filename or data batch name
-	RamsesHeader ramses.Ramses              // Ramses header information
-	RamsesSecure ramses.Secure              // Ramses secure header information
-	SourceHeader innosat.SourcePacketHeader // Source header from the innosat platform
-	TMHeader     innosat.TMDataFieldHeader  // Data header information
+	Origin       OriginDescription          `json:"origin"`       // Describes the origin of the data like filename or data batch name
+	RamsesHeader ramses.Ramses              `json:"ramsesHeader"` // Ramses header information
+	RamsesSecure ramses.Secure              `json:"-"`            // Ramses secure header information
+	SourceHeader innosat.SourcePacketHeader `json:"sourceHeader"` // Source header from the innosat platform
+	TMHeader     innosat.TMDataFieldHeader  `json:"tmHeader"`     // Data header information
 	SID          aez.SID                    // SID of the Data if any
 	RID          aez.RID                    // RID of Data if any
-	Data         Exportable                 // The data payload itself, HK report, jpeg image etc.
-	Error        error                      // First propagated error from the decoding process
-	Buffer       []byte                     // Currently unprocessed data (payload)
+	Data         Exportable                 `json:"data"`  // The data payload itself, HK report, jpeg image etc.
+	Error        error                      `json:"error"` // First propagated error from the decoding process
+	Buffer       []byte                     `json:"-"`     // Currently unprocessed data (payload)
 }
 
 // CSVSpecifications returns specifications used to generate content in CSV compatible format

--- a/internal/common/origin.go
+++ b/internal/common/origin.go
@@ -4,8 +4,8 @@ import "time"
 
 // OriginDescription describes the origin of ramses packages
 type OriginDescription struct {
-	Name           string    // Name of the batch or file
-	ProcessingDate time.Time // Runtime of the batch
+	Name           string    `json:"name"`           // Name of the batch or file
+	ProcessingDate time.Time `json:"processingTime"` // Runtime of the batch
 }
 
 //CSVHeaders returns the field names

--- a/internal/exports/disk_writer.go
+++ b/internal/exports/disk_writer.go
@@ -108,8 +108,20 @@ func DiskCallbackFactory(
 				// Write metadata only supports DataRecord
 				pkg, ok := expPkg.(common.DataRecord)
 				if ok {
-					png.Encode(imgFile, img)
-					_ = json.NewEncoder(os.Stdout).Encode(&pkg)
+					ext := filepath.Ext(imgFileName)
+					jsonFileName := fmt.Sprintf(
+						"%v.json",
+						imgFileName[0:len(imgFileName)-len(ext)],
+					)
+					jsonFile, err := os.Create(jsonFileName)
+					if err != nil {
+						log.Printf("failed creating %s: %s", jsonFileName, err)
+						panic(err.Error())
+					}
+					err = json.NewEncoder(jsonFile).Encode(&pkg)
+					if err != nil {
+						log.Printf("failed to encode json into %s", jsonFileName)
+					}
 				}
 			}
 		}

--- a/internal/exports/disk_writer.go
+++ b/internal/exports/disk_writer.go
@@ -2,6 +2,7 @@ package exports
 
 import (
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"image/png"
 	"log"
@@ -65,15 +66,15 @@ func DiskCallbackFactory(
 		}
 	}
 
-	callback := func(pkg common.ExportablePackage) {
-		err = pkg.ParsingError()
+	callback := func(expPkg common.ExportablePackage) {
+		err = expPkg.ParsingError()
 		if err != nil {
 			log.Println(err)
 		}
 		if writeImages {
-			switch pkg.AEZData().(type) {
+			switch expPkg.AEZData().(type) {
 			case aez.CCDImage:
-				ccdImage, ok := pkg.AEZData().(aez.CCDImage)
+				ccdImage, ok := expPkg.AEZData().(aez.CCDImage)
 				if !ok {
 					log.Print("Could not understand packet as CCDImage, this should be impossible.")
 					break
@@ -81,7 +82,7 @@ func DiskCallbackFactory(
 				imgFileName := getGrayscaleImageName(output, ccdImage.PackData)
 
 				imgData := getImageData(
-					pkg.RemainingBuffer(),
+					expPkg.RemainingBuffer(),
 					ccdImage.PackData,
 					imgFileName,
 				)
@@ -102,6 +103,14 @@ func DiskCallbackFactory(
 				}
 
 				png.Encode(imgFile, img)
+				defer imgFile.Close()
+
+				// Write metadata only supports DataRecord
+				pkg, ok := expPkg.(common.DataRecord)
+				if ok {
+					png.Encode(imgFile, img)
+					_ = json.NewEncoder(os.Stdout).Encode(&pkg)
+				}
 			}
 		}
 
@@ -109,7 +118,7 @@ func DiskCallbackFactory(
 			return
 		}
 		// Close streams from previous file
-		if pkg.OriginName() != currentOrigin {
+		if expPkg.OriginName() != currentOrigin {
 			if pwrOut != nil {
 				pwrOut.close()
 				pwrOut = nil
@@ -130,56 +139,56 @@ func DiskCallbackFactory(
 				pmOut.close()
 				pmOut = nil
 			}
-			currentOrigin = pkg.OriginName()
+			currentOrigin = expPkg.OriginName()
 		}
 
 		// We have nowhere to write partial extraction of record so we discard
-		if pkg.AEZData() == nil {
+		if expPkg.AEZData() == nil {
 			return
 		}
 
 		// Write to the dedicated target stream
-		switch pkg.AEZData().(type) {
+		switch expPkg.AEZData().(type) {
 		case aez.STAT:
 			if statOut == nil {
-				statOut, err = csvOutputFactory(output, currentOrigin, "STAT", &pkg)
+				statOut, err = csvOutputFactory(output, currentOrigin, "STAT", &expPkg)
 				if err != nil {
 					log.Fatal(err)
 				}
 			}
-			err = statOut.writeData(pkg.CSVRow())
+			err = statOut.writeData(expPkg.CSVRow())
 		case aez.HTR:
 			if htrOut == nil {
-				htrOut, err = csvOutputFactory(output, currentOrigin, "HTR", &pkg)
+				htrOut, err = csvOutputFactory(output, currentOrigin, "HTR", &expPkg)
 				if err != nil {
 					log.Fatal(err)
 				}
 			}
-			err = htrOut.writeData(pkg.CSVRow())
+			err = htrOut.writeData(expPkg.CSVRow())
 		case aez.PWR:
 			if pwrOut == nil {
-				pwrOut, err = csvOutputFactory(output, currentOrigin, "PWR", &pkg)
+				pwrOut, err = csvOutputFactory(output, currentOrigin, "PWR", &expPkg)
 				if err != nil {
 					log.Fatal(err)
 				}
 			}
-			err = pwrOut.writeData(pkg.CSVRow())
+			err = pwrOut.writeData(expPkg.CSVRow())
 		case aez.CPRU:
 			if cpruOut == nil {
-				cpruOut, err = csvOutputFactory(output, currentOrigin, "CPRU", &pkg)
+				cpruOut, err = csvOutputFactory(output, currentOrigin, "CPRU", &expPkg)
 				if err != nil {
 					log.Fatal(err)
 				}
 			}
-			err = cpruOut.writeData(pkg.CSVRow())
+			err = cpruOut.writeData(expPkg.CSVRow())
 		case aez.PMData:
 			if pmOut == nil {
-				pmOut, err = csvOutputFactory(output, currentOrigin, "PM", &pkg)
+				pmOut, err = csvOutputFactory(output, currentOrigin, "PM", &expPkg)
 				if err != nil {
 					log.Fatal(err)
 				}
 			}
-			err = pmOut.writeData(pkg.CSVRow())
+			err = pmOut.writeData(expPkg.CSVRow())
 		}
 		// This error comes from writing a line and most probably would be a column missmatch
 		// that means we should be able to continue and just report the error

--- a/internal/exports/disk_writer.go
+++ b/internal/exports/disk_writer.go
@@ -103,7 +103,6 @@ func DiskCallbackFactory(
 				}
 
 				png.Encode(imgFile, img)
-				defer imgFile.Close()
 
 				// Write metadata only supports DataRecord
 				pkg, ok := expPkg.(common.DataRecord)
@@ -114,6 +113,7 @@ func DiskCallbackFactory(
 						imgFileName[0:len(imgFileName)-len(ext)],
 					)
 					jsonFile, err := os.Create(jsonFileName)
+					defer jsonFile.Close()
 					if err != nil {
 						log.Printf("failed creating %s: %s", jsonFileName, err)
 						panic(err.Error())

--- a/internal/exports/disk_writer_test.go
+++ b/internal/exports/disk_writer_test.go
@@ -40,9 +40,9 @@ func TestDiskCallbackFactory(t *testing.T) {
 		writeTimeseries bool
 	}
 	type wantFile struct {
-		base   string
-		lines  int
-		binary bool
+		base           string
+		lines          int
+		dontCountLines bool
 	}
 	tests := []struct {
 		name         string
@@ -191,7 +191,7 @@ func TestDiskCallbackFactory(t *testing.T) {
 			},
 		},
 		{
-			"Creates images",
+			"Creates images and jsons",
 			args{writeImages: true},
 			[]common.DataRecord{
 				{
@@ -219,7 +219,9 @@ func TestDiskCallbackFactory(t *testing.T) {
 			},
 			[]wantFile{
 				{"5000000000.png", 0, true},
+				{"5000000000.json", 0, true},
 				{"6000000000.png", 0, true},
+				{"6000000000.json", 0, true},
 			},
 		},
 		{
@@ -266,7 +268,7 @@ func TestDiskCallbackFactory(t *testing.T) {
 				if err != nil {
 					t.Errorf("DiskCallbackFactory() expected to produce file '%v', but got error reading it: %v", path, err)
 				}
-				if !want.binary {
+				if !want.dontCountLines {
 					if newLines := strings.Count(string(content), "\n"); newLines != want.lines {
 						t.Errorf("DiskCallbackFactory() expected file %v to have %v lines, found %v", want.base, want.lines, newLines)
 					}

--- a/internal/innosat/source.go
+++ b/internal/innosat/source.go
@@ -2,6 +2,7 @@ package innosat
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"io"
 )
@@ -120,4 +121,15 @@ func (sph SourcePacketHeader) CSVRow() []string {
 	return []string{
 		fmt.Sprintf("%v", sph.PacketSequenceControl.SequenceCount()),
 	}
+}
+
+// MarshalJSON makes a custom json of what is of interest in the struct
+func (sph *SourcePacketHeader) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Specification   string `json:"specification"`
+		SPSequenceCount uint16 `json:"spSequenceCount"`
+	}{
+		Specification:   Specification,
+		SPSequenceCount: sph.PacketSequenceControl.SequenceCount(),
+	})
 }

--- a/internal/innosat/source_test.go
+++ b/internal/innosat/source_test.go
@@ -1,6 +1,7 @@
 package innosat
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -212,6 +213,44 @@ func TestSourcePacketHeader_CSVRow(t *testing.T) {
 			}
 			if got := sph.CSVRow(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("SourcePacketHeader.CSVRow() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSourcePacketHeader_MarshalJSON(t *testing.T) {
+	type fields struct {
+		PacketID              packetID
+		PacketSequenceControl PacketSequenceControl
+		PacketLength          uint16
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    []byte
+		wantErr bool
+	}{
+		{
+			"Marshals into expected json",
+			fields{PacketSequenceControl: 0xc008},
+			[]byte(fmt.Sprintf("{\"specification\":\"%s\",\"spSequenceCount\":8}", Specification)),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sph := &SourcePacketHeader{
+				PacketID:              tt.fields.PacketID,
+				PacketSequenceControl: tt.fields.PacketSequenceControl,
+				PacketLength:          tt.fields.PacketLength,
+			}
+			got, err := sph.MarshalJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SourcePacketHeader.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SourcePacketHeader.MarshalJSON() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/innosat/telemetry.go
+++ b/internal/innosat/telemetry.go
@@ -2,6 +2,7 @@ package innosat
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"io"
 	"time"
@@ -58,12 +59,24 @@ func (tmdfh TMDataFieldHeader) CSVHeaders() []string {
 	}
 }
 
+var gpsTime = time.Date(1980, time.January, 6, 0, 0, 0, 0, time.UTC)
+
 // CSVRow returns the data row
 func (tmdfh TMDataFieldHeader) CSVRow() []string {
-	gpsTime := time.Date(1980, time.January, 6, 0, 0, 0, 0, time.UTC)
 	tmTime := tmdfh.Time(gpsTime)
 	return []string{
 		tmTime.Format(time.RFC3339Nano),
 		fmt.Sprintf("%v", tmdfh.Nanoseconds()),
 	}
+}
+
+// MarshalJSON makes a custom json of what is of interest in the struct
+func (tmdfh *TMDataFieldHeader) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		TMHeaderTime        string `json:"tmHeaderTime"`
+		TMHeaderNanoseconds int64  `json:"tmHeaderNanoseconds"`
+	}{
+		TMHeaderTime:        tmdfh.Time(gpsTime).Format(time.RFC3339Nano),
+		TMHeaderNanoseconds: tmdfh.Nanoseconds(),
+	})
 }

--- a/internal/innosat/telemetry_test.go
+++ b/internal/innosat/telemetry_test.go
@@ -243,3 +243,45 @@ func TestTMDataFieldHeader_CSVRow(t *testing.T) {
 		})
 	}
 }
+
+func TestTMDataFieldHeader_MarshalJSON(t *testing.T) {
+	type fields struct {
+		PUS             pus
+		ServiceType     SourcePackageServiceType
+		ServiceSubType  uint8
+		CUCTimeSeconds  uint32
+		CUCTimeFraction uint16
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    []byte
+		wantErr bool
+	}{
+		{
+			"Marshals into expected json",
+			fields{CUCTimeSeconds: 4},
+			[]byte("{\"tmHeaderTime\":\"1980-01-06T00:00:04Z\",\"tmHeaderNanoseconds\":4000000000}"),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmdfh := &TMDataFieldHeader{
+				PUS:             tt.fields.PUS,
+				ServiceType:     tt.fields.ServiceType,
+				ServiceSubType:  tt.fields.ServiceSubType,
+				CUCTimeSeconds:  tt.fields.CUCTimeSeconds,
+				CUCTimeFraction: tt.fields.CUCTimeFraction,
+			}
+			got, err := tmdfh.MarshalJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TMDataFieldHeader.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("TMDataFieldHeader.MarshalJSON() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ramses/ramses.go
+++ b/internal/ramses/ramses.go
@@ -2,6 +2,7 @@ package ramses
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"io"
 	"time"
@@ -56,4 +57,15 @@ func (ramses Ramses) CSVRow() []string {
 	return []string{
 		fmt.Sprintf("%v", ramses.Created().Format(time.RFC3339Nano)),
 	}
+}
+
+// MarshalJSON makes a custom json of what is of interest in the struct
+func (ramses *Ramses) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Specification string `json:"specification"`
+		RamsesTime    string `json:"ramsesTime"`
+	}{
+		Specification: Specification,
+		RamsesTime:    ramses.Created().Format(time.RFC3339Nano),
+	})
 }

--- a/internal/ramses/ramses_test.go
+++ b/internal/ramses/ramses_test.go
@@ -1,6 +1,7 @@
 package ramses
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -191,6 +192,52 @@ func TestRamses_CSVRow(t *testing.T) {
 			}
 			if got := ramses.CSVRow(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Ramses.CSVRow() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRamses_MarshalJSON(t *testing.T) {
+	type fields struct {
+		Synch  uint16
+		Length uint16
+		Port   uint16
+		Type   uint8
+		Secure uint8
+		Time   uint32
+		Date   int32
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    []byte
+		wantErr bool
+	}{
+		{
+			"Marshals into expected json",
+			fields{},
+			[]byte(fmt.Sprintf("{\"specification\":\"%v\",\"ramsesTime\":\"2000-01-01T00:00:00Z\"}", Specification)),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ramses := &Ramses{
+				Synch:  tt.fields.Synch,
+				Length: tt.fields.Length,
+				Port:   tt.fields.Port,
+				Type:   tt.fields.Type,
+				Secure: tt.fields.Secure,
+				Time:   tt.fields.Time,
+				Date:   tt.fields.Date,
+			}
+			got, err := ramses.MarshalJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Ramses.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Ramses.MarshalJSON() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
This is the last part, and thus resolves #20 

Writes a JSON with same filename (`2808949523926.png` -> `2808949523926.json`):
```json
{"origin":{"name":"/home/myname/path/MyArchive1_20200428-204613_20200428-205254.rac","processingTime":"2020-05-08T10:39:47.291542593+02:00"},"ramsesHeader":{"specification":"SPU045-S2:6F","ramsesTime":"2020-04-28T20:46:30.305Z"},"sourceHeader":{"specification":"IS-OSE-ICD-0005:1","spSequenceCount":8573},"tmHeader":{"tmHeaderTime":"1980-01-06T00:46:56.12802124Z","tmHeaderNanoseconds":2816128021240},"SID":"","RID":"CCD3","data":{"PackData":{"CCDSEL":3,"EXPTS":2808,"EXPTSS":62228,"WDW":1,"WDWOV":0,"JPEGQ":95,"FRAME":46,"NROW":250,"NRBIN":2,"NRSKIP":0,"NCOL":500,"NCBIN":4,"NCSKIP":0,"NFLUSH":1023,"TEXPMS":5000,"GAIN":0,"TEMP":4124,"FBINOV":0,"LBLNK":289,"TBLNK":302,"ZERO":121,"TIMING1":5149,"TIMING2":518,"VERSION":50,"TIMING3":41987,"NBC":0},"BadColumns":[]}}
```

**Note that:**
* No specific formatting of `CCDImage` so `PackData` and `BadColumns` instead of camelCase.
* No specific formatting of `CCDImageDataPack` which means that several complex parameters such as `EXPTS` and `EXPTSS` isn't converted to nanoseconds / date, also `WDW`, `NCBIN` and `GAIN` have complex interpretations and really should be read out better, I think. 

I'll make an issue of this unless you require it included in this iteration.