### PR TITLE
Not ready yet to compile for windows.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,14 +29,11 @@ jobs:
             dep ensure
         fi
 
-    - name: Build windows
-      run: GOOS=windows GOARCH=amd64 go build -o rac.exe ./cmd/rac  
-
     - name: Build linux 
       run: go build -o rac ./cmd/rac 
     
     - name: Creating release
       uses: ncipollo/release-action@v1
       with:
-        artifacts: "rac,rac.exe"
+        artifacts: "rac"
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Linking in the "linux static library" into the Windows binary didn't work (as suspected). Removing this feature for now - hopefully we can include a windows binary in later releases.