### PR TITLE
Performance

### DIFF
--- a/cmd/rac/cli.go
+++ b/cmd/rac/cli.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/innosat-mats/rac-extract-payload/internal/common"
@@ -42,6 +43,7 @@ func getCallback(
 	outputDirectory string,
 	skipImages bool,
 	skipTimeseries bool,
+	wg *sync.WaitGroup,
 ) (common.Callback, common.CallbackTeardown, error) {
 	if outputDirectory == "" && !stdout {
 		flag.Usage()
@@ -60,6 +62,7 @@ func getCallback(
 		outputDirectory,
 		!skipImages,
 		!skipTimeseries,
+		wg,
 	)
 	return callback, teardown, nil
 }
@@ -98,13 +101,14 @@ func init() {
 }
 
 func main() {
+	var wg sync.WaitGroup
 	flag.Parse()
 	inputFiles := flag.Args()
 	if len(inputFiles) == 0 {
 		flag.Usage()
 		log.Fatal("No rac-files supplied")
 	}
-	callback, teardown, err := getCallback(*stdout, *outputDirectory, *skipImages, *skipTimeseries)
+	callback, teardown, err := getCallback(*stdout, *outputDirectory, *skipImages, *skipTimeseries, &wg)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/rac/cli_test.go
+++ b/cmd/rac/cli_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,6 +20,7 @@ func Test_getCallback(t *testing.T) {
 		outputDirectory string
 		skipImages      bool
 		skipTimeseries  bool
+		wg              *sync.WaitGroup
 	}
 	tests := []struct {
 		name    string
@@ -31,7 +33,7 @@ func Test_getCallback(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := getCallback(tt.args.stdout, tt.args.outputDirectory, tt.args.skipImages, tt.args.skipTimeseries)
+			_, _, err := getCallback(tt.args.stdout, tt.args.outputDirectory, tt.args.skipImages, tt.args.skipTimeseries, tt.args.wg)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getCallback() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/internal/exports/disk_writer_test.go
+++ b/internal/exports/disk_writer_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/innosat-mats/rac-extract-payload/internal/aez"
@@ -38,6 +39,7 @@ func TestDiskCallbackFactory(t *testing.T) {
 	type args struct {
 		writeImages     bool
 		writeTimeseries bool
+		wg              *sync.WaitGroup
 	}
 	type wantFile struct {
 		base           string
@@ -245,6 +247,7 @@ func TestDiskCallbackFactory(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt.args.wg = &sync.WaitGroup{}
 			// Setup and cleanup of output directory
 			dir, err := ioutil.TempDir("", "innosat-mats")
 			if err != nil {
@@ -253,7 +256,7 @@ func TestDiskCallbackFactory(t *testing.T) {
 			defer os.RemoveAll(dir)
 
 			// Produce callback and teardown
-			callback, teardown := DiskCallbackFactory(dir, tt.args.writeImages, tt.args.writeTimeseries)
+			callback, teardown := DiskCallbackFactory(dir, tt.args.writeImages, tt.args.writeTimeseries, tt.args.wg)
 
 			// Invoke callback and then teardown
 			for _, pkg := range tt.callbackArgs {


### PR DESCRIPTION
Trace analysis showed that png-encoding was the major event, blocking other threads to spawn. This runs the png file creation in a separate go routine.