### PR TITLE
Image files contains rac file name in name

### DIFF
--- a/internal/exports/disk_writer.go
+++ b/internal/exports/disk_writer.go
@@ -82,7 +82,7 @@ func DiskCallbackFactory(
 					log.Print("Could not understand packet as CCDImage, this should be impossible.")
 					break
 				}
-				imgFileName := getGrayscaleImageName(output, ccdImage.PackData)
+				imgFileName := getGrayscaleImageName(output, pkg.Origin.Name, ccdImage.PackData)
 
 				imgData := getImageData(
 					pkg.Buffer,

--- a/internal/exports/disk_writer_test.go
+++ b/internal/exports/disk_writer_test.go
@@ -232,6 +232,7 @@ func TestDiskCallbackFactory(t *testing.T) {
 			args{writeImages: true},
 			[]common.DataRecord{
 				{
+					Origin: common.OriginDescription{Name: "File1.rac"},
 					Data: aez.CCDImage{
 						PackData: aez.CCDImagePackData{
 							JPEGQ: aez.JPEGQUncompressed16bit,
@@ -243,6 +244,7 @@ func TestDiskCallbackFactory(t *testing.T) {
 					Buffer: []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 				},
 				{
+					Origin: common.OriginDescription{Name: "File1.rac"},
 					Data: aez.CCDImage{
 						PackData: aez.CCDImagePackData{
 							JPEGQ: aez.JPEGQUncompressed16bit,
@@ -255,10 +257,10 @@ func TestDiskCallbackFactory(t *testing.T) {
 				},
 			},
 			[]wantFile{
-				{"5000000000.png", 0, true},
-				{"5000000000.json", 0, true},
-				{"6000000000.png", 0, true},
-				{"6000000000.json", 0, true},
+				{"File1_5000000000.png", 0, true},
+				{"File1_5000000000.json", 0, true},
+				{"File1_6000000000.png", 0, true},
+				{"File1_6000000000.json", 0, true},
 			},
 		},
 		{

--- a/internal/exports/images.go
+++ b/internal/exports/images.go
@@ -7,6 +7,7 @@ import (
 	"image"
 	"log"
 	"path/filepath"
+	"strings"
 
 	"github.com/innosat-mats/rac-extract-payload/internal/aez"
 	"github.com/innosat-mats/rac-extract-payload/internal/decodejpeg"
@@ -49,10 +50,11 @@ func getGrayscaleImage(
 	return img
 }
 
-func getGrayscaleImageName(dir string, imgPackData aez.CCDImagePackData) string {
+func getGrayscaleImageName(dir string, originName string, imgPackData aez.CCDImagePackData) string {
+	racName := strings.TrimSuffix(filepath.Base(originName), filepath.Ext(originName))
 	return filepath.Join(
 		dir,
-		fmt.Sprintf("%v.png", imgPackData.Nanoseconds()),
+		fmt.Sprintf("%v_%v.png", racName, imgPackData.Nanoseconds()),
 	)
 }
 

--- a/internal/exports/images_test.go
+++ b/internal/exports/images_test.go
@@ -12,27 +12,10 @@ import (
 )
 
 func Test_getGrayscaleImageName(t *testing.T) {
-	type args struct {
-		dir         string
-		imgPackData aez.CCDImagePackData
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{
-			"Uses nanos in filename",
-			args{"test", aez.CCDImagePackData{EXPTS: 5}},
-			filepath.Join("test", "5000000000.png"),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := getGrayscaleImageName(tt.args.dir, tt.args.imgPackData); got != tt.want {
-				t.Errorf("getGrayscaleImageName() = %v, want %v", got, tt.want)
-			}
-		})
+	want := filepath.Join("test", "MyFile_5000000000.png")
+	got := getGrayscaleImageName("test", "my/path/MyFile.rac", aez.CCDImagePackData{EXPTS: 5})
+	if got != want {
+		t.Errorf("getGrayscaleImageName() = %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
Before `12141242141.png` now `MyRacFile_12141242141.png`.
This makes it easier to find the matching time series csv files and avoids collisions now that the clock resets on the ground.

Resolves #86 