### PR TITLE
Static compilation

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,12 +16,6 @@ jobs:
         go-version: 1.14
       id: go
 
-    - name: setup env
-      run: |
-        echo "::set-env name=GOPATH::$(go env GOPATH)"
-        echo "::add-path::$(go env GOPATH)/bin"
-        go env
-
     - name: install mingw
       run : sudo apt-get install -y gcc-mingw-w64
 
@@ -42,10 +36,7 @@ jobs:
       run: make build
 
     - name: Lint
-      run: |
-        go install golang.org/x/lint/golint
-        go vet ./...
-        golint ./...
+      run: make lint
 
     - name: Test
       run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,26 @@
-# Go parameters
 GOPATH ?= $(HOME)/go
 GOBIN ?= $(GOPATH)/bin
 GOCMD := go
 GOBUILD := $(GOCMD) build
-GOCLEAN := $(GOCMD) clean
-GOTEST := $(GOCMD) test
 GOVET := ${GOCMD} vet
 GOLINT := $(GOBIN)/golint
+GOTEST := $(GOCMD) test
 GOINSTALL := $(GOCMD) install
+GOCLEAN := $(GOCMD) clean
+GOGET := $(GOCMD) get 
+TOOLS := golang.org/x/lint/golint
 
 all: build lint test install
 build:
-	$(GOBUILD) -ldflags='-extldflags=-static' ./...
-lint:
+	$(GOBUILD) ./...
+lint: tools
 	${GOVET} ./...
 	${GOLINT} ./...
 test:
-	$(GOTEST) -ldflags='-extldflags=-static' ./...
+	$(GOTEST) ./...
 install:
-	$(GOINSTALL) -i -ldflags='-extldflags=-static' ./...
+	$(GOINSTALL) -i ./...
 clean:
 	$(GOCLEAN) -i -cache ./...
-
+tools:
+	$(GOGET) $(TOOLS)

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/aws/aws-sdk-go v1.31.0
 	github.com/howeyc/crc16 v0.0.0-20171223171357-2b2a61e366a6
 	github.com/jbuchbinder/gopnm v0.0.0-20150223212718-5176c556b9ce
-	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
+	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,6 @@
-github.com/aws/aws-sdk-go v1.30.27 h1:9gPjZWVDSoQrBO2AvqrWObS6KAZByfEJxQoCYo4ZfK0=
-github.com/aws/aws-sdk-go v1.30.27/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.31.0 h1:ITLZ0oy7IOB1NGt2Ee75bLevBaH1jaAXE2eyGbPRbCg=
 github.com/aws/aws-sdk-go v1.31.0/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/howeyc/crc16 v0.0.0-20171223171357-2b2a61e366a6 h1:IIVxLyDUYErC950b8kecjoqDet8P5S4lcVRUOM6rdkU=
@@ -12,8 +11,10 @@ github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -22,13 +23,17 @@ golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPI
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7 h1:EBZoQjiKKPaLbPrbpssUfuHtwM6KV/vb4U85g/cigFY=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/decodejpeg/decode.go
+++ b/internal/decodejpeg/decode.go
@@ -1,9 +1,9 @@
 package decodejpeg
 
 // #cgo windows CFLAGS: -I${SRCDIR}/../../third-party/windows/include
-// #cgo windows LDFLAGS: -L${SRCDIR}/../../third-party/windows/lib -Wl,-rpath,$ORIGIN/../lib -ljpeg
+// #cgo windows LDFLAGS: ${SRCDIR}/../../third-party/windows/lib/libjpeg.a
 // #cgo linux CFLAGS: -I${SRCDIR}/../../third-party/linux/include
-// #cgo linux LDFLAGS: -L${SRCDIR}/../../third-party/linux/lib -Wl,-rpath,$ORIGIN/../lib -ljpeg
+// #cgo linux LDFLAGS: ${SRCDIR}/../../third-party/linux/lib/libjpeg.a
 // #cgo darwin CFLAGS: -I${SRCDIR}/../../third-party/darwin/include
 // #cgo darwin LDFLAGS: -L/${SRCDIR}/../../third-party/darwin/lib -Wl,-rpath,$ORIGIN/../lib -ljpeg
 // #include <stdlib.h>

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,9 @@
+// +build tools
+
+// Package tools keeps track of our development tools.
+// https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
+package tools
+
+import (
+	_ "golang.org/x/lint" // Linting
+)


### PR DESCRIPTION
Resolves #97 - VSC can build and test code.

Fixes some build/CI problems - "make lint" runs in CI in the same way as for users.

Golint version is specifically set in tools.go - i.e. `go mod tidy` can run without removing golint dependency.