### PR TITLE
Including build info into application

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 GOPATH ?= $(HOME)/go
 GOBIN ?= $(GOPATH)/bin
 GOCMD := go
-
+ifeq ($(OS),Windows_NT)
+SHELL := git-bash.exe
+endif
 # Fetch build info
 HEAD := $(shell git rev-parse --short HEAD)
 BUILDTIME := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,24 @@
 GOPATH ?= $(HOME)/go
 GOBIN ?= $(GOPATH)/bin
 GOCMD := go
-GOBUILD := $(GOCMD) build
+
+# Fetch build info
+HEAD := $(shell git rev-parse --short HEAD)
+BUILDTIME := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
+VERSION := $(shell git describe --tags)
+# Prepare flags
+GOLDFLAGS += -X main.Head=$(HEAD)
+GOLDFLAGS += -X main.Version=$(VERSION)
+GOLDFLAGS += -X main.Buildtime=$(BUILDTIME)
+GOFLAGS = -ldflags "$(GOLDFLAGS)"
+
+GOBUILD := $(GOCMD) build $(GOFLAGS)
 GOVET := ${GOCMD} vet
 GOLINT := $(GOBIN)/golint
 GOTEST := $(GOCMD) test
-GOINSTALL := $(GOCMD) install
+GOINSTALL := $(GOCMD) install $(GOFLAGS)
 GOCLEAN := $(GOCMD) clean
-GOGET := $(GOCMD) get 
+GOGET := $(GOCMD) get
 TOOLS := golang.org/x/lint/golint
 
 all: build lint test install

--- a/cmd/rac/cli.go
+++ b/cmd/rac/cli.go
@@ -15,12 +15,22 @@ import (
 	"github.com/innosat-mats/rac-extract-payload/internal/extractors"
 )
 
+// Version is the version of the source code
+var Version string
+
+// Head is the short commit id of head
+var Head string
+
+// Buildtime is the time of the build
+var Buildtime string
+
 var skipImages *bool
 var skipTimeseries *bool
 var project *string
 var stdout *bool
 var aws *bool
 var awsDescription *string
+var version *bool
 
 //myUsage replaces default usage since it doesn't include information on non-flags
 func myUsage() {
@@ -108,18 +118,53 @@ func processFiles(
 }
 
 func init() {
+	common.Version = Version
+	common.Head = Head
+	common.Buildtime = Buildtime
+
 	skipImages = flag.Bool("skip-images", false, "Extract images from rac-files.\n(Default: false)")
-	skipTimeseries = flag.Bool("skip-timeseries", false, "Extract timeseries from rac-files.\n(Default: false)")
-	project = flag.String("project", "", "Name for experiments, when outputting to disk a directory will be created with this name, when sending to AWS files will have this as a prefix")
-	stdout = flag.Bool("stdout", false, "Output to standard out instead of to disk (only timeseries)\n(Default: false)")
-	aws = flag.Bool("aws", false, "Output to aws instead of disk (requires credentials and permissions)")
-	awsDescription = flag.String("description", "", "Path to a file containing a project description to be uploaded to AWS")
+	skipTimeseries = flag.Bool(
+		"skip-timeseries",
+		false,
+		"Extract timeseries from rac-files.\n(Default: false)",
+	)
+	project = flag.String(
+		"project",
+		"",
+		"Name for experiments, when outputting to disk a directory will be created with this name, when sending to AWS files will have this as a prefix",
+	)
+	stdout = flag.Bool(
+		"stdout",
+		false,
+		"Output to standard out instead of to disk (only timeseries)\n(Default: false)",
+	)
+	aws = flag.Bool(
+		"aws",
+		false,
+		"Output to aws instead of disk (requires credentials and permissions)",
+	)
+	awsDescription = flag.String(
+		"description",
+		"",
+		"Path to a file containing a project description to be uploaded to AWS",
+	)
+	version = flag.Bool(
+		"version",
+		false,
+		"Only display current version of the program",
+	)
+
 	flag.Usage = myUsage
 }
 
 func main() {
 	var wg sync.WaitGroup
 	flag.Parse()
+	if *version {
+		fmt.Println("Version", Version, "Commit", Head, "@", Buildtime)
+		return
+	}
+
 	inputFiles := flag.Args()
 	if len(inputFiles) == 0 {
 		flag.Usage()

--- a/internal/common/datarecord.go
+++ b/internal/common/datarecord.go
@@ -71,7 +71,7 @@ func (record *DataRecord) MarshalJSON() ([]byte, error) {
 
 // CSVSpecifications returns specifications used to generate content in CSV compatible format
 func (record DataRecord) CSVSpecifications() []string {
-	var specifications []string
+	specifications := []string{"CODE", FullVersion()}
 	specifications = append(
 		specifications,
 		record.RamsesHeader.CSVSpecifications()...,

--- a/internal/common/datarecord_test.go
+++ b/internal/common/datarecord_test.go
@@ -34,7 +34,11 @@ func TestDataRecord_CSVSpecifications(t *testing.T) {
 		{
 			"Works on empty package",
 			fields{},
-			[]string{"RAMSES", ramses.Specification, "INNOSAT", innosat.Specification},
+			[]string{
+				"CODE", FullVersion(),
+				"RAMSES", ramses.Specification,
+				"INNOSAT", innosat.Specification,
+			},
 		},
 		{
 			"Returns specs",
@@ -44,6 +48,7 @@ func TestDataRecord_CSVSpecifications(t *testing.T) {
 				Data:         aez.HTR{},
 			},
 			[]string{
+				"CODE", FullVersion(),
 				"RAMSES", ramses.Specification,
 				"INNOSAT", innosat.Specification,
 				"AEZ", aez.Specification,

--- a/internal/common/version.go
+++ b/internal/common/version.go
@@ -1,0 +1,21 @@
+package common
+
+import "fmt"
+
+// Version is the version of the source code
+var Version string
+
+// Head is the short commit id of head
+var Head string
+
+// Buildtime is the time of the build
+var Buildtime string
+
+// FullVersion returns a complete version string
+func FullVersion() string {
+	if Version == "" && Head == "" && Buildtime == "" {
+		return "Test Build"
+	}
+
+	return fmt.Sprintf("%v (%v) @ %v", Version, Head, Buildtime)
+}

--- a/internal/common/version_test.go
+++ b/internal/common/version_test.go
@@ -1,0 +1,42 @@
+package common
+
+import "testing"
+
+func TestFullVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		version   string
+		head      string
+		buildtime string
+		want      string
+	}{
+		{name: "Unset causes Test Build", want: "Test Build"},
+		{
+			"Returns full version",
+			"v1.0.0",
+			"12345",
+			"2020-02-02T22:22:22Z",
+			"v1.0.0 (12345) @ 2020-02-02T22:22:22Z",
+		},
+	}
+	var version = Version
+	var head = Head
+	var buildtime = Buildtime
+
+	cleanup := func() {
+		Version = version
+		Head = head
+		Buildtime = buildtime
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Version = tt.version
+			Head = tt.head
+			Buildtime = tt.buildtime
+			defer cleanup()
+			if got := FullVersion(); got != tt.want {
+				t.Errorf("FullVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/exports/aws_s3_writer_test.go
+++ b/internal/exports/aws_s3_writer_test.go
@@ -164,8 +164,8 @@ func TestAWSS3CallbackFactory(t *testing.T) {
 				"myproj/ABOUT.json":            7,
 				"myproj/MyRac_5000000000.png":  76,  // 8 + header
 				"myproj/MyRac_5000000000.json": 853, // length of the json
-				"myproj/CCD.csv":               649, // length of the first three lines csv (specs, header, datarow)
-				"myproj/HTR.csv":               975,
+				"myproj/CCD.csv":               665, // length of the first three lines csv (specs, header, datarow)
+				"myproj/HTR.csv":               991,
 			},
 		},
 	}


### PR DESCRIPTION
Adding a cli flag:
```
$ ~/go/bin/rac -version
Version v0.2.0 Commit e39b988 @ 2020-05-25T07:29:30Z
```

Adding info in the specifications row of the csv headers:

```
$ head -n 2 out/CCD.csv
CODE,v0.2.0 (e39b988) @ 2020-05-25T07:29:30Z,RAMSES,SPU045-S2:6F,INNOSAT,IS-OSE-ICD-0005:1,Specification,AEZICD002:H
File,ProcessingDate,RamsesTime,...
```

I tried to directly place the variables in `common.Version` etc. instead of `main.Version` but that doesn't seem to work and though a bit ugly perhaps this solution of `main` transferring its values to `common` is :ok: ?

@joakimmoller Is this working on windows?

The if-case in the `FullVersion` function is mostly there for testing. Building tests with ldflags didn't seem to work and besides this makes tests cases nicer.

**Limitation**: The version is just the most recent tag on the repository, so if we tag for other reason than making a release it will show that tag instead of the proper version.

Resolves #29 