### PR TITLE
Only release notes configuration

### DIFF
--- a/release-notes.yml
+++ b/release-notes.yml
@@ -1,0 +1,21 @@
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## Changes since $PREVIOUS_TAG
+
+  $CHANGES
+categories:
+    - title: '🚀 Features'
+      labels:
+        - 'feature'
+        - 'enhancement'
+    - title: '🐛 Bug Fixes'
+      labels:
+        - 'fix'
+        - 'bugfix'
+        - 'bug'
+    - title: '📋 Documentation'
+      label: 'documentation'
+    - title: '🧰 Maintenance'
+      labels:
+        - 'chore'
+        - 'system'


### PR DESCRIPTION
Because the way release notes are collected, they only work if this configuration is in master. So I need it there to be able to test the new release automation.

The action uses https://github.com/marketplace/actions/release-drafter