### PR TITLE
Issue 128 Don't Panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/aws/aws-sdk-go v1.31.0
 	github.com/howeyc/crc16 v0.0.0-20171223171357-2b2a61e366a6
 	github.com/jbuchbinder/gopnm v0.0.0-20150223212718-5176c556b9ce
-	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
+	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5
 )

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 h1:2M3HP5CCK1Si9FQhwnzYhXdG6DXeebvUHFpre8QvbyI=
+golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/internal/exports/aws_s3_writer.go
+++ b/internal/exports/aws_s3_writer.go
@@ -67,7 +67,7 @@ func AWSS3CallbackFactory(
 		recoverWrite := func(imageFileName string) {
 			if r := recover(); r != nil {
 				log.Printf(
-					"Could not process image %s (%v)",
+					"Processing incomplete for image %s, skipping (%v)",
 					imageFileName, r,
 				)
 			}

--- a/internal/exports/aws_s3_writer.go
+++ b/internal/exports/aws_s3_writer.go
@@ -64,6 +64,14 @@ func AWSS3CallbackFactory(
 			log.Println(pkg.Error)
 			return
 		}
+		recoverWrite := func(imageFileName string) {
+			if r := recover(); r != nil {
+				log.Printf(
+					"Could not process image %s (%v)",
+					imageFileName, r,
+				)
+			}
+		}
 		if writeImages {
 			switch pkg.Data.(type) {
 			case *aez.CCDImage:
@@ -77,11 +85,14 @@ func AWSS3CallbackFactory(
 				go func() {
 					defer wg.Done()
 					imgFileName := ccdImage.FullImageName(project)
+					defer recoverWrite(imgFileName)
 					img := ccdImage.Image(pkg.Buffer)
 					pngBuffer := bytes.NewBuffer([]byte{})
-					png.Encode(pngBuffer, img)
+					err := png.Encode(pngBuffer, img)
+					if err != nil {
+						log.Panicf("failed encoding %s: %s", imgFileName, err)
+					}
 					upload(uploader, imgFileName, pngBuffer)
-
 					jsonFileName := GetJSONFilename(imgFileName)
 					jsonBuffer := bytes.NewBuffer([]byte{})
 					WriteJSON(jsonBuffer, &pkg, jsonFileName)

--- a/internal/exports/aws_s3_writer_test.go
+++ b/internal/exports/aws_s3_writer_test.go
@@ -103,6 +103,55 @@ func TestAWSS3CallbackFactory(t *testing.T) {
 			},
 		},
 		{
+			"Skips image with wrong image shape",
+			args{
+				project:     "myproj",
+				writeImages: true,
+			},
+			[]common.DataRecord{
+				{
+					Origin:         &common.OriginDescription{Name: "MyRac.rac"},
+					RamsesHeader:   &ramses.Ramses{},
+					RamsesTMHeader: &ramses.TMHeader{},
+					SourceHeader:   &innosat.SourcePacketHeader{},
+					TMHeader:       &innosat.TMHeader{},
+					RID:            aez.CCD5,
+					Data: &aez.CCDImage{
+						PackData: &aez.CCDImagePackData{
+							EXPTS: 5,
+							JPEGQ: aez.JPEGQUncompressed16bit,
+							NCOL:  42,
+							NROW:  42,
+						},
+						ImageFileName: "MyRac_wrong_shape_5.png",
+					},
+					Buffer: make([]byte, 2*2*2), // 2x2 pixels, 2 bytes per pix
+				},
+				{
+					Origin:         &common.OriginDescription{Name: "MyRac.rac"},
+					RamsesHeader:   &ramses.Ramses{},
+					RamsesTMHeader: &ramses.TMHeader{},
+					SourceHeader:   &innosat.SourcePacketHeader{},
+					TMHeader:       &innosat.TMHeader{},
+					RID:            aez.CCD5,
+					Data: &aez.CCDImage{
+						PackData: &aez.CCDImagePackData{
+							EXPTS: 5,
+							JPEGQ: aez.JPEGQUncompressed16bit,
+							NCOL:  1,
+							NROW:  2,
+						},
+						ImageFileName: "MyRac_5000000000_5.png",
+					},
+					Buffer: make([]byte, 2*2*2), // 2x2 pixels, 2 bytes per pix
+				},
+			},
+			map[string]int{
+				"myproj/MyRac_5000000000_5.png":  76,  // 8 + header
+				"myproj/MyRac_5000000000_5.json": 876, // length of the json
+			},
+		},
+		{
 			"Doesn't upload image when told not to",
 			args{
 				project:     "myproj",

--- a/internal/exports/disk_writer.go
+++ b/internal/exports/disk_writer.go
@@ -57,8 +57,8 @@ func DiskCallbackFactory(
 		recoverWrite := func(imageFileName string) {
 			if r := recover(); r != nil {
 				log.Printf(
-					"Could not process image %s (skipping...)",
-					imageFileName,
+					"Could not process image %s (%v)",
+					imageFileName, r,
 				)
 			}
 		}
@@ -75,24 +75,22 @@ func DiskCallbackFactory(
 				go func() {
 					defer wg.Done()
 					imgFileName := ccdImage.FullImageName(output)
-					// png.Encode is known to be able to panic, but recovery is
-					// defered here, in case something else also misbehave
 					defer recoverWrite(imgFileName)
 					img := ccdImage.Image(pkg.Buffer)
 					imgFile, err := os.Create(imgFileName)
 					if err != nil {
-						log.Fatalf("failed creating %s: %s", imgFileName, err)
+						log.Panicf("failed creating %s: %s", imgFileName, err)
 					}
 					defer imgFile.Close()
 					err = png.Encode(imgFile, img)
 					if err != nil {
-						log.Fatalf("failed encoding %s: %s", imgFileName, err)
+						log.Panicf("failed encoding %s: %s", imgFileName, err)
 					}
 					jsonFileName := GetJSONFilename(imgFileName)
 					jsonFile, err := os.Create(jsonFileName)
 					defer jsonFile.Close()
 					if err != nil {
-						log.Fatalf("failed creating %s: %s", jsonFileName, err)
+						log.Panicf("failed creating %s: %s", jsonFileName, err)
 					}
 					WriteJSON(jsonFile, &pkg, jsonFileName)
 				}()

--- a/internal/exports/disk_writer.go
+++ b/internal/exports/disk_writer.go
@@ -60,6 +60,8 @@ func DiskCallbackFactory(
 					"Could not process image %s (%v)",
 					imageFileName, r,
 				)
+				os.Remove(imageFileName)
+				os.Remove(GetJSONFilename(imageFileName))
 			}
 		}
 		if writeImages {

--- a/internal/exports/disk_writer.go
+++ b/internal/exports/disk_writer.go
@@ -57,7 +57,7 @@ func DiskCallbackFactory(
 		recoverWrite := func(imageFileName string) {
 			if r := recover(); r != nil {
 				log.Printf(
-					"Could not process image %s (%v)",
+					"Processing incomplete for image %s, skipping (%v)",
 					imageFileName, r,
 				)
 				os.Remove(imageFileName)

--- a/internal/exports/disk_writer_test.go
+++ b/internal/exports/disk_writer_test.go
@@ -273,7 +273,7 @@ func TestDiskCallbackFactoryCreator(t *testing.T) {
 			},
 		},
 		{
-			"Continues on error",
+			"Continues on error due to wrong image shape",
 			args{writeImages: true},
 			[]common.DataRecord{
 				{
@@ -286,7 +286,7 @@ func TestDiskCallbackFactoryCreator(t *testing.T) {
 							NROW:  42,
 							EXPTS: 5,
 						},
-						ImageFileName: "File1_5000000000_2.png",
+						ImageFileName: "File1_wrong_shape_2.png",
 					},
 					Buffer: []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 				},
@@ -306,7 +306,7 @@ func TestDiskCallbackFactoryCreator(t *testing.T) {
 				},
 			},
 			[]wantFile{
-				{"File1_5000000000_2.png", 0, true},
+				{"File1_wrong_shape_2.png", 0, true},
 				{"File1_6000000000_3.png", 0, true},
 				{"File1_6000000000_3.json", 0, true},
 			},

--- a/internal/exports/disk_writer_test.go
+++ b/internal/exports/disk_writer_test.go
@@ -273,6 +273,45 @@ func TestDiskCallbackFactoryCreator(t *testing.T) {
 			},
 		},
 		{
+			"Continues on error",
+			args{writeImages: true},
+			[]common.DataRecord{
+				{
+					RID:    aez.CCD2,
+					Origin: &common.OriginDescription{Name: "File1.rac"},
+					Data: &aez.CCDImage{
+						PackData: &aez.CCDImagePackData{
+							JPEGQ: aez.JPEGQUncompressed16bit,
+							NCOL:  42,
+							NROW:  42,
+							EXPTS: 5,
+						},
+						ImageFileName: "File1_5000000000_2.png",
+					},
+					Buffer: []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+				},
+				{
+					RID:    aez.CCD3,
+					Origin: &common.OriginDescription{Name: "File1.rac"},
+					Data: &aez.CCDImage{
+						PackData: &aez.CCDImagePackData{
+							JPEGQ: aez.JPEGQUncompressed16bit,
+							NCOL:  1,
+							NROW:  2,
+							EXPTS: 6,
+						},
+						ImageFileName: "File1_6000000000_3.png",
+					},
+					Buffer: []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+				},
+			},
+			[]wantFile{
+				{"File1_5000000000_2.png", 0, true},
+				{"File1_6000000000_3.png", 0, true},
+				{"File1_6000000000_3.json", 0, true},
+			},
+		},
+		{
 			"Doesn't creates images when asked not to",
 			args{writeImages: false},
 			[]common.DataRecord{

--- a/internal/exports/disk_writer_test.go
+++ b/internal/exports/disk_writer_test.go
@@ -306,7 +306,6 @@ func TestDiskCallbackFactoryCreator(t *testing.T) {
 				},
 			},
 			[]wantFile{
-				{"File1_wrong_shape_2.png", 0, true},
 				{"File1_6000000000_3.png", 0, true},
 				{"File1_6000000000_3.json", 0, true},
 			},


### PR DESCRIPTION
This resolves #128 by writing a message to the user when an image can't be processed properly, and then continuing to process the rest of the files.

General review aside, some input on these points would be appreciated:
1) ~I'm not sure how to test it. I have tested the file manually and it works, producing more output now than before, but not sure if unit tests are feasible. Suggestions?~ FIXED (but see 3!)
2) ~I don't remember how to bump the version. Is this done by creating a tag and release on GitHub manually..?~ ANSWERED by @local-minimum below
3) ~The bad `png` image is still created as far as it gets, but no corresponding `json` will be created. This might cause problems later, so maybe it should be removed in the recovery process?~ FIXED (broken files are cleaned up)

Number 3 is probably a question for both @OleMartinChristensen and @innosat-mats/molflow 

This is what the offending image looks like if you stretch the contrast, by the way:
![image](https://user-images.githubusercontent.com/358614/116574855-668bb400-a90e-11eb-9ca3-8afffa1defbb.png)
