### PR TITLE
Fixed a stats thing

### DIFF
--- a/internal/common/errorstats.go
+++ b/internal/common/errorstats.go
@@ -1,0 +1,57 @@
+package common
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ErrorStats ...
+type ErrorStats struct {
+	total       uint // errors and not errors
+	errorsCount uint
+	errors      map[string]uint
+}
+
+// NewErrorStats ...
+func NewErrorStats() ErrorStats {
+	return ErrorStats{errors: make(map[string]uint)}
+}
+
+// Register a new error or not error occurnace
+func (stats *ErrorStats) Register(err error) {
+	stats.total++
+	if err != nil {
+		stats.errorsCount++
+		stats.errors[err.Error()]++
+	}
+
+}
+
+// Summarize ...
+func (stats *ErrorStats) Summarize() string {
+	errs := make([]struct {
+		string
+		uint
+	}, 0)
+	for key, value := range stats.errors {
+		errs = append(errs, struct {
+			string
+			uint
+		}{key, value})
+	}
+	sort.SliceStable(errs, func(i, j int) bool {
+		return errs[i].uint > errs[j].uint
+	})
+	lines := make([]string, 0)
+	for _, item := range errs {
+		lines = append(lines, fmt.Sprintf("%v\t%s", item.uint, item.string))
+	}
+
+	return fmt.Sprintf(
+		"\nStatistics\n\nCount\tError Message\n%s\n\nTotal Errors:\t%v\nTotal Packages:\t%v\n",
+		strings.Join(lines, "\n"),
+		stats.errorsCount,
+		stats.total,
+	)
+}

--- a/internal/common/errorstats.go
+++ b/internal/common/errorstats.go
@@ -29,7 +29,7 @@ func (stats *ErrorStats) Register(err error) {
 
 }
 
-func Max(x, y uint) uint {
+func max(x, y uint) uint {
 	if x < y {
 		return y
 	}
@@ -51,7 +51,7 @@ func (stats *ErrorStats) Summarize() string {
 	}
 	var indent uint = 5 // "Count" is 5 characters
 	for key, value := range stats.errors {
-		indent = Max(indent, uint(len(strconv.Itoa(int(value)))))
+		indent = max(indent, uint(len(strconv.Itoa(int(value)))))
 		errs = append(errs, struct {
 			string
 			uint

--- a/internal/common/errorstats_test.go
+++ b/internal/common/errorstats_test.go
@@ -1,0 +1,60 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestErrorStats_Register_and_Summarize(t *testing.T) {
+	tests := []struct {
+		name            string
+		errs            []error
+		wantTotal       uint
+		wantTotalErrors uint
+		wantErrors      []string
+	}{
+		{
+			"Empty",
+			[]error{},
+			0,
+			0,
+			[]string{},
+		},
+		{
+			"Some Errors",
+			[]error{
+				errors.New("test"),
+				nil,
+				io.ErrUnexpectedEOF,
+				nil,
+				io.ErrUnexpectedEOF,
+			},
+			5,
+			3,
+			[]string{
+				"2\tunexpected EOF",
+				"1\ttest",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stats := NewErrorStats()
+			for _, err := range tt.errs {
+				stats.Register(err)
+			}
+			want := fmt.Sprintf(
+				"\nStatistics\n\nCount\tError Message\n%s\n\nTotal Errors:\t%v\nTotal Packages:\t%v\n",
+				strings.Join(tt.wantErrors, "\n"),
+				tt.wantTotalErrors,
+				tt.wantTotal,
+			)
+			if got := stats.Summarize(); got != want {
+				t.Errorf("ErrorStats.Summarize() = %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/internal/common/errorstats_test.go
+++ b/internal/common/errorstats_test.go
@@ -35,8 +35,8 @@ func TestErrorStats_Register_and_Summarize(t *testing.T) {
 			5,
 			3,
 			[]string{
-				"2\tunexpected EOF",
-				"1\ttest",
+				"2       unexpected EOF",
+				"1       test",
 			},
 		},
 	}
@@ -46,12 +46,21 @@ func TestErrorStats_Register_and_Summarize(t *testing.T) {
 			for _, err := range tt.errs {
 				stats.Register(err)
 			}
-			want := fmt.Sprintf(
-				"\nStatistics\n\nCount\tError Message\n%s\n\nTotal Errors:\t%v\nTotal Packages:\t%v\n",
-				strings.Join(tt.wantErrors, "\n"),
-				tt.wantTotalErrors,
-				tt.wantTotal,
-			)
+			var want string
+			if len(tt.errs) == 0 {
+				want = fmt.Sprintf(
+					"\nStatistics\n\nTotal Errors:\t%v\nTotal Packages:\t%v\n",
+					tt.wantTotalErrors,
+					tt.wantTotal,
+				)
+			} else {
+				want = fmt.Sprintf(
+					"\nStatistics\n\nCount   Error Message\n%s\n\nTotal Errors:\t%v\nTotal Packages:\t%v\n",
+					strings.Join(tt.wantErrors, "\n"),
+					tt.wantTotalErrors,
+					tt.wantTotal,
+				)
+			}
 			if got := stats.Summarize(); got != want {
 				t.Errorf("ErrorStats.Summarize() = %v, want %v", got, want)
 			}

--- a/internal/exports/disk_writer.go
+++ b/internal/exports/disk_writer.go
@@ -41,6 +41,7 @@ func DiskCallbackFactory(
 ) (common.Callback, common.CallbackTeardown) {
 	var err error
 	timeseriesCollection := timeseries.NewCollection(csvFileWriterFactoryCreator(output))
+	errorStats := common.NewErrorStats()
 
 	if writeImages || writeTimeseries {
 		// Create Directory and File
@@ -51,6 +52,7 @@ func DiskCallbackFactory(
 	}
 
 	callback := func(pkg common.DataRecord) {
+		errorStats.Register(pkg.Error)
 		if pkg.Error != nil {
 			pkg.Error = fmt.Errorf(
 				"%s %s",
@@ -117,6 +119,7 @@ func DiskCallbackFactory(
 	teardown := func() {
 		timeseriesCollection.CloseAll()
 		wg.Wait()
+		log.Println(errorStats.Summarize())
 	}
 
 	return callback, teardown


### PR DESCRIPTION
For all three targets (stdout, disk, aws) we now get a final report.

Example usage:
```
$ rac -skip-images -skip-timeseries -stdout All\ Packets\ VC0_20210518-145413_20210519-094004.rac
Nothing will be extracted, only validating integrity of rac-file(s)

Statistics

Count    Error Message
116370   unhandled SID 2
43460    unhandled SID 4
36677    unhandled SID 3
24440    unhandled SID 5
12255    unhandled SID 7
12214    unhandled SID 6
8696     unexpected EOF
6146     unhandled SID 12
6146     unhandled SID 13
2021     orphaned multi-package data without termination detected
615      unhandled SID 9
408      unhandled SID 0
20       got continuation packet without a start packet
17       the TMHeader isn't recognized as either housekeeping, transparent or verification data (Service Type 5, Service Sub Type 1)
17       got stop packet without a start packet
5        the TMHeader isn't recognized as either housekeeping, transparent or verification data (Service Type 5, Service Sub Type 2)
1        the TMHeader isn't recognized as either housekeeping, transparent or verification data (Service Type 17, Service Sub Type 2)

Total Errors:	269508
Total Packages:	278014

```
Note that report omits the information about what package is the source of the error to be able to aggregate them better.

Resolves #130 