### PR TITLE
Make raclambda get triggered by l0fetcher events

### DIFF
--- a/raclambda/app.py
+++ b/raclambda/app.py
@@ -39,6 +39,7 @@ RacLambdaStack(
     input_bucket_name="mats-l0-raw",
     output_bucket_name="mats-l0-artifacts",
     project_name=os.environ.get("RAC_PROJECT", "mats-test-project"),
+    queue_arn_export_name="L0RACFetcherStackOutputQueue"
 )
 
 app.synth()


### PR DESCRIPTION
The rac lambda will now listen to SQS events published by L0Fetcher. Each event triggers a single rac lambda and all files in that event message will be processed.

Resolves #141 