### PR TITLE
Write different schemas

### DIFF
--- a/cmd/rac/output.go
+++ b/cmd/rac/output.go
@@ -254,9 +254,8 @@ func infoParquet() {
 ### Parquet files ###
 
 The parquet files follow the same naming conventions used in the CSVs, but the
-header row is stored as meta-data instead. Parquet files support variable length
-rows, so instead of one file per packet type, one file per input file is
-produced.
+header row is stored as meta-data instead. Rather than one file per parameter
+and batch, one file per parameter and input file is produced.
 
 In addition, the parquet files are written using a partitioning scheme so that
 data for each day is written to a file in a directory for that day. This means
@@ -268,8 +267,7 @@ When writing to parquet the PNG-files are stored in the parquet files
 themselves, rather than as separate files. This introduces two new columns:
 - ImageName: The name of the PNG-image, if it had been written to disk
 - ImageData: The parsed PNG data
-
- `)
+  `)
 }
 
 func infoSpace() {

--- a/internal/exports/parquet_writer.go
+++ b/internal/exports/parquet_writer.go
@@ -11,16 +11,16 @@ import (
 	"github.com/innosat-mats/rac-extract-payload/internal/timeseries"
 )
 
-func parquetName(dir string, pkg *common.DataRecord) string {
-	name := timeseries.ParquetName(pkg)
+func parquetName(dir string, pkg *common.DataRecord, stream timeseries.OutStream) string {
+	name := timeseries.ParquetName(pkg, stream)
 	return filepath.Join(dir, name)
 }
 
 func parquetFileWriterFactoryCreator(
 	dir string,
 ) timeseries.ParquetFactory {
-	return func(pkg *common.DataRecord) (timeseries.ParquetWriter, error) {
-		outPath := parquetName(dir, pkg)
+	return func(pkg *common.DataRecord, stream timeseries.OutStream) (timeseries.ParquetWriter, error) {
+		outPath := parquetName(dir, pkg, stream)
 
 		err := os.MkdirAll(filepath.Dir(outPath), os.ModePerm)
 		if err != nil {

--- a/internal/exports/parquet_writer_test.go
+++ b/internal/exports/parquet_writer_test.go
@@ -11,12 +11,14 @@ import (
 	"github.com/innosat-mats/rac-extract-payload/internal/common"
 	"github.com/innosat-mats/rac-extract-payload/internal/innosat"
 	"github.com/innosat-mats/rac-extract-payload/internal/ramses"
+	"github.com/innosat-mats/rac-extract-payload/internal/timeseries"
 )
 
 func Test_parquetName(t *testing.T) {
 	type args struct {
 		dir    string
 		packet common.DataRecord
+		stream timeseries.OutStream
 	}
 	record := common.DataRecord{
 		Origin:         &common.OriginDescription{Name: "File1.rac"},
@@ -26,17 +28,18 @@ func Test_parquetName(t *testing.T) {
 		TMHeader:       &innosat.TMHeader{},
 		Data:           &aez.STAT{},
 	}
+	stream := timeseries.OutStreamFromDataRecord(&record)
 	tests := []struct {
 		name string
 		args args
 		want string
 	}{
-		{"Case 1", args{".", record}, filepath.FromSlash("1980/1/5/File1.parquet")},
-		{"Case 2", args{"my/dir", record}, filepath.FromSlash("my/dir/1980/1/5/File1.parquet")},
+		{"Case 1", args{".", record, stream}, filepath.FromSlash("1980/1/5/STAT_File1.parquet")},
+		{"Case 2", args{"my/dir", record, stream}, filepath.FromSlash("my/dir/1980/1/5/STAT_File1.parquet")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := parquetName(tt.args.dir, &tt.args.packet); got != tt.want {
+			if got := parquetName(tt.args.dir, &tt.args.packet, tt.args.stream); got != tt.want {
 				t.Errorf("parquetName() = %v, want %v", got, tt.want)
 			}
 		})
@@ -79,7 +82,7 @@ func TestParquetCallbackFactoryCreator(t *testing.T) {
 				},
 			},
 			[]wantFile{
-				{"File1.parquet"},
+				{"STAT_File1.parquet"},
 			},
 		},
 		{
@@ -104,8 +107,8 @@ func TestParquetCallbackFactoryCreator(t *testing.T) {
 				},
 			},
 			[]wantFile{
-				{"File1.parquet"},
-				{"File2.parquet"},
+				{"STAT_File1.parquet"},
+				{"STAT_File2.parquet"},
 			},
 		},
 		{
@@ -218,7 +221,12 @@ func TestParquetCallbackFactoryCreator(t *testing.T) {
 				},
 			},
 			[]wantFile{
-				{"File1.parquet"},
+				{"CPRU_File1.parquet"},
+				{"HTR_File1.parquet"},
+				{"PM_File1.parquet"},
+				{"PWR_File1.parquet"},
+				{"STAT_File1.parquet"},
+				{"TCV_File1.parquet"},
 			},
 		},
 		{
@@ -257,8 +265,8 @@ func TestParquetCallbackFactoryCreator(t *testing.T) {
 				},
 			},
 			[]wantFile{
-				{"File1.parquet"},
-				{"File2.parquet"},
+				{"CCD_File1.parquet"},
+				{"CCD_File2.parquet"},
 			},
 		},
 		/*

--- a/internal/parquetrow/parquet_schema.go
+++ b/internal/parquetrow/parquet_schema.go
@@ -1,5 +1,310 @@
 package parquetrow
 
+// RacCCDSchema is the parquet schema for saving RAC CCD data, one row per packet
+const RacCCDSchema = `message schema {
+	required binary OriginFile (STRING);
+	required int64  ProcessingTime (TIMESTAMP(NANOS, true));
+	required int64  RamsesTime (TIMESTAMP(NANOS, true));
+	required int32  QualityIndicator;
+	required int32  LossFlag;
+	required int32  VCFrameCounter;
+	required int32  SPSequenceCount;
+	required int64  TMHeaderTime (TIMESTAMP(NANOS, true));
+	required int64  TMHeaderNanoseconds;
+	required binary SID (STRING);
+	required binary RID (STRING);
+
+	required int32  CCDSEL;
+	required int64  EXPNanoseconds;
+	required int64  EXPDate (TIMESTAMP(MICROS, true));
+	required binary WDWMode (STRING);
+	required binary WDWInputDataWindow (STRING);
+	required int32  WDWOV;
+	required int32  JPEGQ;
+	required int32  FRAME;
+	required int32  NROW;
+	required int32  NRBIN;
+	required int32  NRSKIP;
+	required int32  NCOL;
+	required int32  NCBINFPGAColumns;
+	required int32  NCBINCCDColumns;
+	required int32  NCSKIP;
+	required int32  NFLUSH;
+	required int32  TEXPMS;
+	required binary GAINMode (STRING);
+	required binary GAINTiming (STRING);
+	required int32  GAINTruncation;
+	required int32  TEMP;
+	required int32  FBINOV;
+	required int32  LBLNK;
+	required int32  TBLNK;
+	required int32  ZERO;
+	required int32  TIMING1;
+	required int32  TIMING2;
+	required int32  VERSION;
+	required int32  TIMING3;
+	required int32  NBC;
+	required group  BadColumns (LIST) {
+		repeated group list {
+			required int32 element;
+		}
+	}
+	required binary ImageName (STRING);
+	required binary ImageData;
+
+	optional group Warnings (LIST) {
+		repeated group list {
+			required binary element (STRING);
+		}
+	}
+	optional group Errors (LIST) {
+		repeated group list {
+			required binary element (STRING);
+		}
+	}
+}`
+
+// RacPMSchema is the parquet schema for saving RAC PM data, one row per packet
+const RacPMSchema = `message schema {
+	required binary OriginFile (STRING);
+	required int64  ProcessingTime (TIMESTAMP(NANOS, true));
+	required int64  RamsesTime (TIMESTAMP(NANOS, true));
+	required int32  QualityIndicator;
+	required int32  LossFlag;
+	required int32  VCFrameCounter;
+	required int32  SPSequenceCount;
+	required int64  TMHeaderTime (TIMESTAMP(NANOS, true));
+	required int64  TMHeaderNanoseconds;
+	required binary SID (STRING);
+	required binary RID (STRING);
+
+	required int64 PMTime (TIMESTAMP(NANOS, true));
+	required int64 PMNanoseconds;
+	required int32 PM1A;
+	required int32 PM1ACNTR;
+	required int32 PM1B;
+	required int32 PM1BCNTR;
+	required int32 PM1S;
+	required int32 PM1SCNTR;
+	required int32 PM2A;
+	required int32 PM2ACNTR;
+	required int32 PM2B;
+	required int32 PM2BCNTR;
+	required int32 PM2S;
+	required int32 PM2SCNTR;
+
+	optional group Warnings (LIST) {
+		repeated group list {
+			required binary element (STRING);
+		}
+	}
+	optional group Errors (LIST) {
+		repeated group list {
+			required binary element (STRING);
+		}
+	}
+}`
+
+// RacHTRSchema is the parquet schema for saving RAC HTR data, one row per packet
+const RacHTRSchema = `message schema {
+	required binary OriginFile (STRING);
+	required int64  ProcessingTime (TIMESTAMP(NANOS, true));
+	required int64  RamsesTime (TIMESTAMP(NANOS, true));
+	required int32  QualityIndicator;
+	required int32  LossFlag;
+	required int32  VCFrameCounter;
+	required int32  SPSequenceCount;
+	required int64  TMHeaderTime (TIMESTAMP(NANOS, true));
+	required int64  TMHeaderNanoseconds;
+	required binary SID (STRING);
+	required binary RID (STRING);
+
+	required double HTR1A;
+	required double HTR1B;
+	required double HTR1OD;
+	required double HTR2A;
+	required double HTR2B;
+	required double HTR2OD;
+	required double HTR7A;
+	required double HTR7B;
+	required double HTR7OD;
+	required double HTR8A;
+	required double HTR8B;
+	required double HTR8OD;
+
+	optional group Warnings (LIST) {
+		repeated group list {
+			required binary element (STRING);
+		}
+	}
+	optional group Errors (LIST) {
+		repeated group list {
+			required binary element (STRING);
+		}
+	}
+}`
+
+// RacPWRSchema is the parquet schema for saving RAC PWR data, one row per packet
+const RacPWRSchema = `message schema {
+	required binary OriginFile (STRING);
+	required int64  ProcessingTime (TIMESTAMP(NANOS, true));
+	required int64  RamsesTime (TIMESTAMP(NANOS, true));
+	required int32  QualityIndicator;
+	required int32  LossFlag;
+	required int32  VCFrameCounter;
+	required int32  SPSequenceCount;
+	required int64  TMHeaderTime (TIMESTAMP(NANOS, true));
+	required int64  TMHeaderNanoseconds;
+	required binary SID (STRING);
+	required binary RID (STRING);
+
+	required double PWRT;
+	required double PWRP32V;
+	required double PWRP32C;
+	required double PWRP16V;
+	required double PWRP16C;
+	required double PWRM16V;
+	required double PWRM16C;
+	required double PWRP3V3;
+	required double PWRP3C3;
+
+	optional group Warnings (LIST) {
+		repeated group list {
+			required binary element (STRING);
+		}
+	}
+	optional group Errors (LIST) {
+		repeated group list {
+			required binary element (STRING);
+		}
+	}
+}`
+
+// RacCPRUSchema is the parquet schema for saving RAC CPRU data, one row per packet
+const RacCPRUSchema = `message schema {
+	required binary OriginFile (STRING);
+	required int64  ProcessingTime (TIMESTAMP(NANOS, true));
+	required int64  RamsesTime (TIMESTAMP(NANOS, true));
+	required int32  QualityIndicator;
+	required int32  LossFlag;
+	required int32  VCFrameCounter;
+	required int32  SPSequenceCount;
+	required int64  TMHeaderTime (TIMESTAMP(NANOS, true));
+	required int64  TMHeaderNanoseconds;
+	required binary SID (STRING);
+	required binary RID (STRING);
+
+	required double  VGATE0;
+	required double  VSUBS0;
+	required double  VRD0;
+	required double  VOD0;
+	required boolean Overvoltage0;
+	required boolean Power0;
+	required double  VGATE1;
+	required double  VSUBS1;
+	required double  VRD1;
+	required double  VOD1;
+	required boolean Overvoltage1;
+	required boolean Power1;
+	required double  VGATE2;
+	required double  VSUBS2;
+	required double  VRD2;
+	required double  VOD2;
+	required boolean Overvoltage2;
+	required boolean Power2;
+	required double  VGATE3;
+	required double  VSUBS3;
+	required double  VRD3;
+	required double  VOD3;
+	required boolean Overvoltage3;
+	required boolean Power3;
+
+	optional group Warnings (LIST) {
+		repeated group list {
+			required binary element (STRING);
+		}
+	}
+	optional group Errors (LIST) {
+		repeated group list {
+			required binary element (STRING);
+		}
+	}
+}`
+
+// RacSTATSchema is the parquet schema for saving RAC STAT data, one row per packet
+const RacSTATSchema = `message schema {
+	required binary OriginFile (STRING);
+	required int64  ProcessingTime (TIMESTAMP(NANOS, true));
+	required int64  RamsesTime (TIMESTAMP(NANOS, true));
+	required int32  QualityIndicator;
+	required int32  LossFlag;
+	required int32  VCFrameCounter;
+	required int32  SPSequenceCount;
+	required int64  TMHeaderTime (TIMESTAMP(NANOS, true));
+	required int64  TMHeaderNanoseconds;
+	required binary SID (STRING);
+	required binary RID (STRING);
+
+	required int64 STATTime (TIMESTAMP(NANOS, true));
+	required int64 STATNanoseconds;
+	required int32 SPID;
+	required int32 SPREV;
+	required int32 FPID;
+	required int32 FPREV;
+	required int32 SVNA;
+	required int32 SVNB;
+	required int32 SVNC;
+	required int32 MODE;
+	required int32 EDACE;
+	required int32 EDACCE;
+	required int32 EDACN;
+	required int32 SPWEOP;
+	required int32 SPWEEP;
+	required int32 ANOMALY;
+
+	optional group Warnings (LIST) {
+		repeated group list {
+			required binary element (STRING);
+		}
+	}
+	optional group Errors (LIST) {
+		repeated group list {
+			required binary element (STRING);
+		}
+	}
+}`
+
+// RacTCVSchema is the parquet schema for saving RAC TCV data, one row per packet
+const RacTCVSchema = `message schema {
+	required binary OriginFile (STRING);
+	required int64  ProcessingTime (TIMESTAMP(NANOS, true));
+	required int64  RamsesTime (TIMESTAMP(NANOS, true));
+	required int32  QualityIndicator;
+	required int32  LossFlag;
+	required int32  VCFrameCounter;
+	required int32  SPSequenceCount;
+	required int64  TMHeaderTime (TIMESTAMP(NANOS, true));
+	required int64  TMHeaderNanoseconds;
+	required binary SID (STRING);
+	required binary RID (STRING);
+
+	required binary TCV (STRING);
+	required int32  TCPID;
+	required int32  PSC;
+	required int32  ErrorCode;
+
+	optional group Warnings (LIST) {
+		repeated group list {
+			required binary element (STRING);
+		}
+	}
+	optional group Errors (LIST) {
+		repeated group list {
+			required binary element (STRING);
+		}
+	}
+}`
+
 // RacSchema is the parquet schema for saving RAC data, one row per packet
 const RacSchema = `message schema {
 	required binary OriginFile (STRING);
@@ -16,7 +321,7 @@ const RacSchema = `message schema {
 
 	optional int32  CCDSEL;
 	optional int64  EXPNanoseconds;
-	optional int64  EXPDate (TIMESTAMP(NANOS, true));
+	optional int64  EXPDate (TIMESTAMP(MICROS, true));
 	optional binary WDWMode (STRING);
 	optional binary WDWInputDataWindow (STRING);
 	optional int32  WDWOV;

--- a/internal/timeseries/parquet.go
+++ b/internal/timeseries/parquet.go
@@ -19,9 +19,21 @@ type Parquet struct {
 	NHeaders      int
 }
 
+var streamToScheme = map[OutStream]string{
+	Unknown: parquetrow.RacSchema,
+	HTR:     parquetrow.RacHTRSchema,
+	PWR:     parquetrow.RacPWRSchema,
+	CPRU:    parquetrow.RacCPRUSchema,
+	STAT:    parquetrow.RacSTATSchema,
+	PM:      parquetrow.RacPMSchema,
+	CCD:     parquetrow.RacCCDSchema,
+	TCV:     parquetrow.RacTCVSchema,
+}
+
 // NewParquet returns a Timeseries as parquet
 func NewParquet(name string, pkg *common.DataRecord) ParquetWriter {
-	sd, err := parquetschema.ParseSchemaDefinition(parquetrow.RacSchema)
+	schema := streamToScheme[OutStreamFromDataRecord(pkg)]
+	sd, err := parquetschema.ParseSchemaDefinition(schema)
 	if err != nil {
 		log.Fatalf("could not parse parquet schema definition: %v", err)
 	}

--- a/internal/timeseries/parquet_collection_test.go
+++ b/internal/timeseries/parquet_collection_test.go
@@ -25,7 +25,32 @@ func TestParquetCollection_Write(t *testing.T) {
 			[]string{},
 		},
 		{
-			"A single streams",
+			"A single stream from same file",
+			[]common.DataRecord{
+				{
+					Origin:         &common.OriginDescription{Name: "test1"},
+					RamsesHeader:   &ramses.Ramses{},
+					RamsesTMHeader: &ramses.TMHeader{},
+					SourceHeader:   &innosat.SourcePacketHeader{},
+					TMHeader:       &innosat.TMHeader{},
+					Data:           &aez.STAT{},
+				},
+				{
+					Origin:         &common.OriginDescription{Name: "test1"},
+					RamsesHeader:   &ramses.Ramses{},
+					RamsesTMHeader: &ramses.TMHeader{},
+					SourceHeader:   &innosat.SourcePacketHeader{},
+					TMHeader:       &innosat.TMHeader{},
+					Data:           &aez.STAT{},
+				},
+			},
+			false,
+			[]string{
+				filepath.FromSlash("1980/1/5/STAT_test1.parquet"),
+			},
+		},
+		{
+			"Two different streams from same file",
 			[]common.DataRecord{
 				{
 					Origin:         &common.OriginDescription{Name: "test1"},
@@ -46,11 +71,12 @@ func TestParquetCollection_Write(t *testing.T) {
 			},
 			false,
 			[]string{
-				filepath.FromSlash("1980/1/5/test1.parquet"),
+				filepath.FromSlash("1980/1/5/HTR_test1.parquet"),
+				filepath.FromSlash("1980/1/5/STAT_test1.parquet"),
 			},
 		},
 		{
-			"Two different streams",
+			"Two different streams from different files",
 			[]common.DataRecord{
 				{
 					Origin:         &common.OriginDescription{Name: "test1"},
@@ -58,7 +84,7 @@ func TestParquetCollection_Write(t *testing.T) {
 					RamsesTMHeader: &ramses.TMHeader{},
 					SourceHeader:   &innosat.SourcePacketHeader{},
 					TMHeader:       &innosat.TMHeader{},
-					Data:           &aez.HTR{},
+					Data:           &aez.STAT{},
 				},
 				{
 					Origin:         &common.OriginDescription{Name: "test2"},
@@ -71,8 +97,8 @@ func TestParquetCollection_Write(t *testing.T) {
 			},
 			false,
 			[]string{
-				filepath.FromSlash("1980/1/5/test1.parquet"),
-				filepath.FromSlash("1980/1/5/test2.parquet"),
+				filepath.FromSlash("1980/1/5/STAT_test1.parquet"),
+				filepath.FromSlash("1980/1/5/STAT_test2.parquet"),
 			},
 		},
 	}
@@ -82,7 +108,7 @@ func TestParquetCollection_Write(t *testing.T) {
 			if err != nil {
 				t.Errorf("ParquetCollection() could not setup output directory '%v'", err)
 			}
-			factory := func(pkg *common.DataRecord) (ParquetWriter, error) {
+			factory := func(pkg *common.DataRecord, stream OutStream) (ParquetWriter, error) {
 				f := filepath.Join(dir, "test")
 				parquet := NewParquet(f, pkg)
 				return parquet, nil


### PR DESCRIPTION
This changes so that parquet files are written to different files based on both packet type and original file, using different parquet schemas. This is preferable, since otherwise golang will helpfully add default values (0) to columns that belong to another packet type, making rows hard to disambiguate. The new file naming scheme also makes it easy to filter what files to read in PyArrow, which might be useful.