### PR TITLE
Updated lambda to output parquet and upload using rclone

### DIFF
--- a/raclambda/app.py
+++ b/raclambda/app.py
@@ -10,7 +10,7 @@ import aws_cdk as cdk
 from raclambda.raclambda_stack import RacLambdaStack
 
 
-RAC_VERSION = "v0.2.7"
+RAC_VERSION = "v1.1.0"
 RAC_OS = "Linux"
 RAC_URL = f"https://github.com/innosat-mats/rac-extract-payload/releases/download/{RAC_VERSION}/Rac_for_{RAC_OS}.tar.gz"  # noqa: E501
 RAC_DIR = "./raclambda/handler"
@@ -39,7 +39,9 @@ RacLambdaStack(
     input_bucket_name="mats-l0-raw",
     output_bucket_name="mats-l0-artifacts",
     project_name=os.environ.get("RAC_PROJECT", "mats-test-project"),
-    queue_arn_export_name="L0RACFetcherStackOutputQueue"
+    queue_arn_export_name="L0RACFetcherStackOutputQueue",
+    config_ssm_name="/rclone/l0-fetcher",
+    rclone_arn="arn:aws:lambda:eu-north-1:968500071567:layer:RCLONE:1",
 )
 
 app.synth()

--- a/raclambda/raclambda/raclambda_stack.py
+++ b/raclambda/raclambda/raclambda_stack.py
@@ -7,6 +7,7 @@ from aws_cdk import (
     aws_lambda as lambda_,
     aws_s3 as s3,
     aws_sqs as sqs,
+    aws_iam as iam,
 )
 from constructs import Construct
 
@@ -25,6 +26,8 @@ class RacLambdaStack(Stack):
         output_bucket_name: str,
         project_name: str,
         queue_arn_export_name: str,
+        config_ssm_name: str,
+        rclone_arn: str,
         lambda_timeout: Duration = Duration.seconds(300),
         dregs_expiration: Duration = Duration.days(7),
         **kwargs,
@@ -54,17 +57,28 @@ class RacLambdaStack(Stack):
             Fn.import_value(queue_arn_export_name)
         )
 
+        rclone_layer = lambda_.LayerVersion.from_layer_version_arn(
+            self,
+            "RCloneLayer",
+            rclone_arn,
+        )
+
         rac_lambda = lambda_.Function(
             self,
             "rac-lambda",
             code=lambda_.InlineCode.from_asset("./raclambda/handler"),
             handler="raclambda_handler.handler",
             timeout=lambda_timeout,
+            architecture=lambda_.Architecture.X86_64,
             runtime=lambda_.Runtime.PYTHON_3_9,
+            memory_size=1024,
             environment={
                 "RAC_PROJECT": project_name,
                 "RAC_DREGS": dregs_bucket.bucket_name,
+                "RAC_OUTPUT": output_bucket.bucket_name,
+                "RCLONE_CONFIG_SSM_NAME": config_ssm_name,
             },
+            layers=[rclone_layer],
         )
 
         rac_lambda.add_event_source(sources.SqsEventSource(
@@ -72,6 +86,12 @@ class RacLambdaStack(Stack):
             batch_size=1,
         ))
 
+        rac_lambda.add_to_role_policy(iam.PolicyStatement(
+            effect=iam.Effect.ALLOW,
+            actions=["ssm:GetParameter"],
+            resources=[f"arn:aws:ssm:*:*:parameter{config_ssm_name}"]
+        ))
+
         input_bucket.grant_read(rac_lambda)
-        output_bucket.grant_put(rac_lambda)
+        output_bucket.grant_read_write(rac_lambda)
         dregs_bucket.grant_read_write(rac_lambda)

--- a/raclambda/tests/raclambda/handler/test_raclambda_handler.py
+++ b/raclambda/tests/raclambda/handler/test_raclambda_handler.py
@@ -1,16 +1,19 @@
 import json
+from pathlib import Path
 from typing import List
 from unittest.mock import ANY, Mock, call, patch
 
+import botocore
 import pytest  # type: ignore
+from botocore.stub import Stubber
 
 from raclambda.handler.raclambda_handler import (
     download_files,
+    format_rclone_command,
     get_env_or_raise,
-    get_new_files,
+    get_rclone_config_path,
     handler,
     parse_event_message,
-    upload_files,
     NothingToDo,
 )
 
@@ -47,33 +50,12 @@ def test_download_files(tmp_path):
     ])
 
 
-def test_get_new_files():
-    path_name = "path"
-    file_names = ["foo", "bar"]
-    with patch(
-        "raclambda.handler.raclambda_handler.glob",
-        return_value=["foo", "bar", "baz"],
-    ):
-        assert get_new_files(path_name, file_names) == ["baz"]
-
-
-def test_upload_files():
-    mocked_client = Mock()
-    bucket_name = "bucket"
-    path_name = "path"
-    file_names = ["file1", "file2"]
-    upload_files(mocked_client, bucket_name, path_name, file_names)
-    mocked_client.upload_file.assert_has_calls([
-        call('bucket', 'file1', 'path/file1'),
-        call('bucket', 'file2', 'path/file2'),
-    ])
-
-
-def test_handle(monkeypatch):
+def test_handler(monkeypatch):
     monkeypatch.setenv("RAC_PROJECT", "rac-project")
     monkeypatch.setenv("RAC_DREGS", "rac-dregs-bucket")
+    monkeypatch.setenv("RAC_OUTPUT", "rac-output-bucket")
+    monkeypatch.setenv("RCLONE_CONFIG_SSM_NAME", "rclone-config")
     rac_files = ["path/to/file.rac", "path/to/other-file.rac"]
-    dregs_files = ["path/to/file.dregs", "path/to/other-file.dregs"]
     event = {
         "Records": [{
             "body": json.dumps({
@@ -85,46 +67,37 @@ def test_handle(monkeypatch):
 
     with patch(
         'raclambda.handler.raclambda_handler.boto3.client',
-    ) as patched_client, patch(
-        'raclambda.handler.raclambda_handler.get_all_files',
-        return_value=dregs_files,
-    ) as patched_get_all, patch(
+    ) as patched_boto, patch(
+        'raclambda.handler.raclambda_handler.get_rclone_config_path',
+        return_value="/rclone/config",
+    ) as patched_rclone_config, patch(
         'raclambda.handler.raclambda_handler.download_files',
     ) as patched_download, patch(
-        'raclambda.handler.raclambda_handler.upload_files',
-    ) as patched_upload, patch(
-        'raclambda.handler.raclambda_handler.get_new_files',
-        return_value=["path/to/new-file.dregs"]
-    ) as patched_get_new, patch(
         'raclambda.handler.raclambda_handler.subprocess.call',
     ) as patched_call:
-        patched_s3 = patched_client.return_value
+        patched_client = patched_boto.return_value
         handler(event, None)
-    patched_client.assert_called_once_with("s3")
-    patched_download.assert_has_calls([
-        call(patched_s3, "rac-bucket", ANY, rac_files),
-        call(patched_s3, "rac-dregs-bucket", ANY, dregs_files),
-    ])
-    patched_get_all.assert_called_once_with("rac-dregs-bucket")
-    patched_call.assert_called_once_with([
-        "./rac",
-        "-aws",
-        "-project", "rac-project",
-        "-dregs", ANY,
-        ANY,
-    ])
-    patched_get_new.assert_called_once_with(ANY, dregs_files)
-    patched_upload.assert_called_once_with(
-        patched_s3,
-        "rac-dregs-bucket",
-        ANY,
-        ["path/to/new-file.dregs"],
+
+    patched_boto.assert_has_calls([call("s3"), call("ssm")], any_order=False)
+    patched_download.assert_called_once_with(
+        patched_client, "rac-bucket", ANY, rac_files,
     )
+    patched_rclone_config.assert_called_once_with(
+        patched_client, "rclone-config",
+    )
+    patched_call.assert_has_calls([
+        call(["rclone", "--config", "/rclone/config", "copy", "S3:rac-dregs-bucket", ANY, "--size-only"]),  # noqa: E501
+        call(["./rac", "-parquet", "-project", ANY, "-dregs", ANY, ANY]),
+        call(["rclone", "--config", "/rclone/config", "copy", ANY, "S3:rac-output-bucket", "--size-only"]),  # noqa: E501
+        call(["rclone", "--config", "/rclone/config", "copy", ANY, "S3:rac-dregs-bucket", "--size-only"]),  # noqa: E501
+    ], any_order=False)
 
 
-def test_handle_raises(monkeypatch):
+def test_handler_raises_nothing_to_do(monkeypatch):
     monkeypatch.setenv("RAC_PROJECT", "rac-project")
     monkeypatch.setenv("RAC_DREGS", "rac-dregs-bucket")
+    monkeypatch.setenv("RAC_OUTPUT", "rac-output-bucket")
+    monkeypatch.setenv("RCLONE_CONFIG_SSM_NAME", "rclone-config")
     rac_files: List[str] = []
     event = {
         "Records": [{
@@ -137,7 +110,37 @@ def test_handle_raises(monkeypatch):
 
     with patch(
         'raclambda.handler.raclambda_handler.boto3.client',
-    ) as patched_client:
+    ) as patched_boto:
         with pytest.raises(NothingToDo):
             handler(event, None)
-    patched_client.assert_called_once_with("s3")
+
+    patched_boto.assert_called_once_with("s3")
+
+
+def test_rclone_config_path():
+    ssm_parameter = "param"
+
+    ssm_client = botocore.session.get_session().create_client(
+        "ssm",
+        region_name="eu-north-1"
+    )
+    stubber = Stubber(ssm_client)
+    stubber.add_response(
+        "get_parameter",
+        {"Parameter": {"Value": "config"}},
+        expected_params={"Name": ssm_parameter, "WithDecryption": True}
+    )
+    stubber.activate()
+
+    name = get_rclone_config_path(ssm_client, ssm_parameter)
+
+    path = Path(name)
+    assert path.exists()
+    assert path.read_text() == "config"
+    path.unlink()
+
+
+def test_format_rclone_command():
+    assert format_rclone_command("config", "from_path", "to_path") == [
+        "rclone", "--config", "config", "copy", "from_path", "to_path", "--size-only",  # noqa: E501
+    ]

--- a/raclambda/tests/raclambda/test_raclambda_stack.py
+++ b/raclambda/tests/raclambda/test_raclambda_stack.py
@@ -17,6 +17,8 @@ def template():
         "output-bucket",
         "test-project",
         "queue-arn",
+        "rclone-config",
+        "rclone-arn",
     )
 
     return Template.from_stack(stack)
@@ -42,6 +44,11 @@ class TestRacLambdaStack:
                             "Resource": {
                                 "Fn::ImportValue": "queue-arn"
                             }
+                        },
+                        {
+                            "Action": "ssm:GetParameter",
+                            "Effect": "Allow",
+                            "Resource": "arn:aws:ssm:*:*:parameterrclone-config"
                         },
                         {
                             "Action": [
@@ -79,6 +86,10 @@ class TestRacLambdaStack:
                         },
                         {
                             "Action": [
+                                "s3:GetObject*",
+                                "s3:GetBucket*",
+                                "s3:List*",
+                                "s3:DeleteObject*",
                                 "s3:PutObject",
                                 "s3:PutObjectLegalHold",
                                 "s3:PutObjectRetention",
@@ -87,18 +98,32 @@ class TestRacLambdaStack:
                                 "s3:Abort*"
                             ],
                             "Effect": "Allow",
-                            "Resource": {
-                                "Fn::Join": [
-                                    "",
-                                    [
-                                        "arn:",
-                                        {
-                                            "Ref": "AWS::Partition"
-                                        },
-                                        ":s3:::output-bucket/*"
+                            "Resource": [
+                                {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "arn:",
+                                            {
+                                                "Ref": "AWS::Partition"
+                                            },
+                                            ":s3:::output-bucket"
+                                        ]
                                     ]
-                                ]
-                            }
+                                },
+                                {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "arn:",
+                                            {
+                                                "Ref": "AWS::Partition"
+                                            },
+                                            ":s3:::output-bucket/*"
+                                        ]
+                                    ]
+                                }
+                            ]
                         },
                         {
                            "Action": [


### PR DESCRIPTION
What it says on the box: Lambda now uses updated rac binary to output parquet. The output is copied to the output bucket by the lambda using rclone. In addition, copying  to and from the dregs bucket is now also performed using rclone.

Final part of #140 