### PR TITLE
Fix error handling in decode jpeg

### DIFF
--- a/internal/decodejpeg/decode.c
+++ b/internal/decodejpeg/decode.c
@@ -1,44 +1,70 @@
+#include <stdio.h>
+#include <setjmp.h>
+
 #include "decode.h"
 
-GLOBAL(struct Image)
-read_JPEG_file(char *inbuffer, size_t size)
+char jpeg_last_error_message[JMSG_LENGTH_MAX];
+
+void jpeg_error_exit (j_common_ptr cinfo)
 {
-  struct Image result;
-  struct jpeg_decompress_struct cinfo;
-  struct jpeg_error_mgr jerr;
+    /* cinfo->err actually points to a jpeg_error_manager struct */
+    JpegErrorManager* myerr = (JpegErrorManager*) cinfo->err;
 
-  const int BYTES_PER_SAMPLE = sizeof(JSAMPLE);
-  JSAMPARRAY buffer; /* Output row buffer */
+    /* output_message is a method to print an error message */
+    ( *(cinfo->err->output_message) ) (cinfo);
 
-  int row_stride; /* physical row width in output buffer */
+    /* Create the message */
+    ( *(cinfo->err->format_message) ) (cinfo, jpeg_last_error_message);
 
-  cinfo.err = jpeg_std_error(&jerr);
+    /* Jump to the setjmp point */
+    longjmp(myerr->setjmp_buffer, 1);
+}
 
-  jpeg_create_decompress(&cinfo);
+GLOBAL(struct Image)
+read_JPEG_file(char* inbuffer, size_t size, char* error)
+{
+    struct Image result;
+    struct jpeg_decompress_struct cinfo;
+    struct JpegErrorManager jerr;
 
-  jpeg_mem_src(&cinfo, inbuffer, size);
+    const int BYTES_PER_SAMPLE = sizeof(JSAMPLE);
+    JSAMPARRAY buffer; /* Output row buffer */
 
-  (void)jpeg_read_header(&cinfo, TRUE);
+    int row_stride; /* physical row width in output buffer */
 
-  (void)jpeg_start_decompress(&cinfo);
-  result.pix = (char *)malloc(cinfo.output_height * cinfo.output_width
-                              * cinfo.output_components * BYTES_PER_SAMPLE);
-  result.width = cinfo.output_width;
-  result.height = cinfo.output_height;
+    cinfo.err = jpeg_std_error(&jerr.pub);
+    jerr.pub.error_exit = jpeg_error_exit;
+    if (setjmp(jerr.setjmp_buffer)) {
+        /* If we get here, the JPEG code has signaled an error. */
+        jpeg_destroy_decompress(&cinfo);
+        strcpy(error, jpeg_last_error_message);
+        return result;
+    }
 
-  row_stride = cinfo.output_width * cinfo.output_components * BYTES_PER_SAMPLE;
-  buffer = (*cinfo.mem->alloc_sarray)((j_common_ptr)&cinfo, JPOOL_IMAGE, row_stride, 1);
+    jpeg_create_decompress(&cinfo);
 
-  while (cinfo.output_scanline < cinfo.output_height)
-  {
-    (void)jpeg_read_scanlines(&cinfo, buffer, 1);
-    memcpy(&(result.pix)[(cinfo.output_scanline - 1) * row_stride],
-           buffer[0],
-           row_stride);
-  }
-  (void)jpeg_finish_decompress(&cinfo);
+    jpeg_mem_src(&cinfo, inbuffer, size);
 
-  jpeg_destroy_decompress(&cinfo);
+    (void)jpeg_read_header(&cinfo, TRUE);
 
-  return result;
+    (void)jpeg_start_decompress(&cinfo);
+    row_stride = cinfo.output_width * cinfo.output_components * BYTES_PER_SAMPLE;
+    result.pix = (char *)malloc(cinfo.output_height * row_stride);
+    result.width = cinfo.output_width;
+    result.height = cinfo.output_height;
+
+    buffer = (*cinfo.mem->alloc_sarray)((j_common_ptr)&cinfo, JPOOL_IMAGE, row_stride, 1);
+
+    while (cinfo.output_scanline < cinfo.output_height)
+    {
+        (void)jpeg_read_scanlines(&cinfo, buffer, 1);
+        memcpy(&(result.pix)[(cinfo.output_scanline - 1) * row_stride],
+               buffer[0],
+               row_stride);
+    }
+    (void)jpeg_finish_decompress(&cinfo);
+
+    jpeg_destroy_decompress(&cinfo);
+
+    return result;
 }

--- a/internal/decodejpeg/decode.go
+++ b/internal/decodejpeg/decode.go
@@ -23,10 +23,7 @@ func JpegImageData(jpegData []byte) (rawData []uint16, height int, width int, er
 	jpegChar := C.CString(string(jpegData))
 	defer C.free(unsafe.Pointer(jpegChar))
 
-	jErrBuf := ""
-	for i := 0; i < C.JMSG_LENGTH_MAX; i++ {
-		jErrBuf += " "
-	}
+	jErrBuf := strings.Repeat(" ", CJMSG_LENGTH_MAX)
 
 	jpegErr := C.CString(string(jErrBuf))
 	defer C.free(unsafe.Pointer(jpegErr))

--- a/internal/decodejpeg/decode.go
+++ b/internal/decodejpeg/decode.go
@@ -23,7 +23,7 @@ func JpegImageData(jpegData []byte) (rawData []uint16, height int, width int, er
 	jpegChar := C.CString(string(jpegData))
 	defer C.free(unsafe.Pointer(jpegChar))
 
-	jErrBuf := strings.Repeat(" ", CJMSG_LENGTH_MAX)
+	jErrBuf := strings.Repeat(" ", C.JMSG_LENGTH_MAX)
 
 	jpegErr := C.CString(string(jErrBuf))
 	defer C.free(unsafe.Pointer(jpegErr))

--- a/internal/decodejpeg/decode.go
+++ b/internal/decodejpeg/decode.go
@@ -12,22 +12,38 @@ import "C"
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"strings"
 	"unsafe"
 )
 
-//JpegImageData converts a grayscale image encoded in 12-bit jpeg to raw data
+// JpegImageData converts a grayscale image encoded in 12-bit jpeg to raw data
 func JpegImageData(jpegData []byte) (rawData []uint16, height int, width int, err error) {
 
 	jpegChar := C.CString(string(jpegData))
 	defer C.free(unsafe.Pointer(jpegChar))
 
-	imageData, err := C.read_JPEG_file(jpegChar, C.size_t(len(jpegData)))
-	if err != nil {
-		return rawData, height, width, err
+	jErrBuf := ""
+	for i := 0; i < C.JMSG_LENGTH_MAX; i++ {
+		jErrBuf += " "
 	}
+
+	jpegErr := C.CString(string(jErrBuf))
+	defer C.free(unsafe.Pointer(jpegErr))
+
+	imageData, err := C.read_JPEG_file(jpegChar, C.size_t(len(jpegData)), jpegErr)
 	defer C.free(unsafe.Pointer(imageData.pix))
 
-	pixelString := C.GoStringN(imageData.pix, C.int(imageData.width*imageData.height*C.sizeof_short))
+	jErr := C.GoStringN(jpegErr, C.JMSG_LENGTH_MAX)
+	jErr = strings.Trim(jErr, " ")
+	if jErr != "" {
+		return rawData, height, width, fmt.Errorf("JPEG decode error: %v", jErr)
+	}
+
+	pixelString := C.GoStringN(
+		imageData.pix,
+		C.int(imageData.width*imageData.height*C.sizeof_short),
+	)
 	height = int(imageData.height)
 	width = int(imageData.width)
 	buffer := bytes.NewBufferString(pixelString)

--- a/internal/decodejpeg/decode.h
+++ b/internal/decodejpeg/decode.h
@@ -1,13 +1,21 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <setjmp.h>
 #include "jpeglib.h"
 
 typedef struct Image
 {
-  char *pix;
+  char* pix;
   JDIMENSION width;
   JDIMENSION height;
 } Image;
 
-struct Image read_JPEG_file(char *, size_t);
+typedef struct JpegErrorManager {
+    /* "public" fields */
+    struct jpeg_error_mgr pub;
+    /* for return to caller */
+    jmp_buf setjmp_buffer;
+} JpegErrorManager;
+
+struct Image read_JPEG_file(char*, size_t, char*);


### PR DESCRIPTION
This fixes the error handling in the JPEG decoding, which resolves #153.

The problem was that LibJPEG:s default error handler has some errors where it issues an `exit()`. The implementer using the library has to override this, if the library is used embedded in another application, see _e.g._ https://github.com/LuaDist/libjpeg/blob/master/example.c

This also fixes at least some error propagation from the decoding to the rest of the code. The method we used before didn't work. This at least propagates the most sever errors, but a lot of other errors (or warnings) issued by LibJPEG can be seen when running `rac` on one of the corrupt files. These other errors are printed by LibJPEG itself, and are currently not handled at all in our code, but they don't cause a crash.

We could handle them like the more severe errors, but the only thing we do with the errors from decoding at the moment is to log them, which LibJPEG sort of already does, so this seems to be of limited use.
