### PR TITLE
Bump rac version in lambda

### DIFF
--- a/raclambda/app.py
+++ b/raclambda/app.py
@@ -10,7 +10,7 @@ import aws_cdk as cdk
 from raclambda.raclambda_stack import RacLambdaStack
 
 
-RAC_VERSION = "v1.1.0"
+RAC_VERSION = "v1.1.1"
 RAC_OS = "Linux"
 RAC_URL = f"https://github.com/innosat-mats/rac-extract-payload/releases/download/{RAC_VERSION}/Rac_for_{RAC_OS}.tar.gz"  # noqa: E501
 RAC_DIR = "./raclambda/handler"


### PR DESCRIPTION
This bumps the version of the rac-binary used in the Lambda function to v1.1.1 (code name: Schooner).