### PR TITLE
Make ImageData optional in schema

### DIFF
--- a/internal/parquetrow/parquet_schema.go
+++ b/internal/parquetrow/parquet_schema.go
@@ -50,7 +50,7 @@ const RacCCDSchema = `message schema {
 		}
 	}
 	required binary ImageName (STRING);
-	required binary ImageData;
+	optional binary ImageData;
 
 	optional group Warnings (LIST) {
 		repeated group list {

--- a/raclambda/app.py
+++ b/raclambda/app.py
@@ -10,7 +10,7 @@ import aws_cdk as cdk
 from raclambda.raclambda_stack import RacLambdaStack
 
 
-RAC_VERSION = "v1.1.1"
+RAC_VERSION = "v1.1.2"
 RAC_OS = "Linux"
 RAC_URL = f"https://github.com/innosat-mats/rac-extract-payload/releases/download/{RAC_VERSION}/Rac_for_{RAC_OS}.tar.gz"  # noqa: E501
 RAC_DIR = "./raclambda/handler"


### PR DESCRIPTION
This makes image-data optional in the Parquet-schema, since sometimes it image generation fails, but we still want the metadata. This preferable and more transparent than setting it to something like `[]byte{0x00}`.