### PR TITLE
Add stream type prefix before partitioning rather than to filename

### DIFF
--- a/internal/exports/parquet_writer_test.go
+++ b/internal/exports/parquet_writer_test.go
@@ -34,8 +34,8 @@ func Test_parquetName(t *testing.T) {
 		args args
 		want string
 	}{
-		{"Case 1", args{".", record, stream}, filepath.FromSlash("1980/1/5/STAT_File1.parquet")},
-		{"Case 2", args{"my/dir", record, stream}, filepath.FromSlash("my/dir/1980/1/5/STAT_File1.parquet")},
+		{"Case 1", args{".", record, stream}, filepath.FromSlash("STAT/1980/1/5/File1.parquet")},
+		{"Case 2", args{"my/dir", record, stream}, filepath.FromSlash("my/dir/STAT/1980/1/5/File1.parquet")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -51,7 +51,8 @@ func TestParquetCallbackFactoryCreator(t *testing.T) {
 		wg *sync.WaitGroup
 	}
 	type wantFile struct {
-		base string
+		prefix string
+		base   string
 	}
 	tests := []struct {
 		name         string
@@ -82,7 +83,7 @@ func TestParquetCallbackFactoryCreator(t *testing.T) {
 				},
 			},
 			[]wantFile{
-				{"STAT_File1.parquet"},
+				{"STAT", "File1.parquet"},
 			},
 		},
 		{
@@ -107,8 +108,8 @@ func TestParquetCallbackFactoryCreator(t *testing.T) {
 				},
 			},
 			[]wantFile{
-				{"STAT_File1.parquet"},
-				{"STAT_File2.parquet"},
+				{"STAT", "File1.parquet"},
+				{"STAT", "File2.parquet"},
 			},
 		},
 		{
@@ -221,12 +222,12 @@ func TestParquetCallbackFactoryCreator(t *testing.T) {
 				},
 			},
 			[]wantFile{
-				{"CPRU_File1.parquet"},
-				{"HTR_File1.parquet"},
-				{"PM_File1.parquet"},
-				{"PWR_File1.parquet"},
-				{"STAT_File1.parquet"},
-				{"TCV_File1.parquet"},
+				{"CPRU", "File1.parquet"},
+				{"HTR", "File1.parquet"},
+				{"PM", "File1.parquet"},
+				{"PWR", "File1.parquet"},
+				{"STAT", "File1.parquet"},
+				{"TCV", "File1.parquet"},
 			},
 		},
 		{
@@ -265,12 +266,10 @@ func TestParquetCallbackFactoryCreator(t *testing.T) {
 				},
 			},
 			[]wantFile{
-				{"CCD_File1.parquet"},
-				{"CCD_File2.parquet"},
+				{"CCD", "File1.parquet"},
+				{"CCD", "File2.parquet"},
 			},
 		},
-		/*
-		 */
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -290,9 +289,9 @@ func TestParquetCallbackFactoryCreator(t *testing.T) {
 			}
 			teardown()
 
-			savePath := filepath.Join(dir, "1980", "1", "5")
 			for _, want := range tt.wantFiles {
-				// Test each output for file name and expected number of lines
+				// Test each output for file name
+				savePath := filepath.Join(dir, want.prefix, "1980", "1", "5")
 				path := filepath.Join(savePath, want.base)
 				_, err := os.ReadFile(path)
 				if err != nil {
@@ -307,23 +306,6 @@ func TestParquetCallbackFactoryCreator(t *testing.T) {
 					}
 				}
 			}
-
-			// Test that number of output files equals expected
-			files, err := os.ReadDir(savePath)
-			if err != nil {
-				t.Errorf("ParquetCallbackFactory() could not read directory: %v", err)
-			}
-			if nFiles, expect := len(files), len(tt.wantFiles); nFiles != expect {
-				t.Errorf(
-					"ParquetCallbackFactory() created %v files, expected %v files",
-					nFiles, expect,
-				)
-				fmt.Printf("Files in %v:\n", savePath)
-				for _, file := range files {
-					fmt.Printf("  %v %v\n", file.Name(), file.IsDir())
-				}
-			}
-
 		})
 	}
 }

--- a/internal/timeseries/parquet_collection.go
+++ b/internal/timeseries/parquet_collection.go
@@ -28,13 +28,14 @@ func NewParquetCollection(factory ParquetFactory) ParquetCollection {
 func ParquetName(pkg *common.DataRecord, stream OutStream) string {
 	tmTime := pkg.TMHeader.Time(time.Time{})
 	prefix := filepath.Join(
+		stream.String(),
 		fmt.Sprintf("%v", tmTime.Year()),
 		fmt.Sprintf("%v", int(tmTime.Month())),
 		fmt.Sprintf("%v", tmTime.Day()),
 	)
 	baseName := filepath.Base(pkg.Origin.Name)
 	ext := filepath.Ext(pkg.Origin.Name)
-	name := fmt.Sprintf("%v_%v.parquet", stream.String(), strings.TrimSuffix(baseName, ext))
+	name := fmt.Sprintf("%v.parquet", strings.TrimSuffix(baseName, ext))
 	return filepath.Join(prefix, name)
 }
 

--- a/internal/timeseries/parquet_collection_test.go
+++ b/internal/timeseries/parquet_collection_test.go
@@ -46,7 +46,7 @@ func TestParquetCollection_Write(t *testing.T) {
 			},
 			false,
 			[]string{
-				filepath.FromSlash("1980/1/5/STAT_test1.parquet"),
+				filepath.FromSlash("STAT/1980/1/5/test1.parquet"),
 			},
 		},
 		{
@@ -71,8 +71,8 @@ func TestParquetCollection_Write(t *testing.T) {
 			},
 			false,
 			[]string{
-				filepath.FromSlash("1980/1/5/HTR_test1.parquet"),
-				filepath.FromSlash("1980/1/5/STAT_test1.parquet"),
+				filepath.FromSlash("HTR/1980/1/5/test1.parquet"),
+				filepath.FromSlash("STAT/1980/1/5/test1.parquet"),
 			},
 		},
 		{
@@ -97,8 +97,8 @@ func TestParquetCollection_Write(t *testing.T) {
 			},
 			false,
 			[]string{
-				filepath.FromSlash("1980/1/5/STAT_test1.parquet"),
-				filepath.FromSlash("1980/1/5/STAT_test2.parquet"),
+				filepath.FromSlash("STAT/1980/1/5/test1.parquet"),
+				filepath.FromSlash("STAT/1980/1/5/test2.parquet"),
 			},
 		},
 	}

--- a/raclambda/app.py
+++ b/raclambda/app.py
@@ -10,7 +10,7 @@ import aws_cdk as cdk
 from raclambda.raclambda_stack import RacLambdaStack
 
 
-RAC_VERSION = "v1.1.2"
+RAC_VERSION = "v1.2.0"
 RAC_OS = "Linux"
 RAC_URL = f"https://github.com/innosat-mats/rac-extract-payload/releases/download/{RAC_VERSION}/Rac_for_{RAC_OS}.tar.gz"  # noqa: E501
 RAC_DIR = "./raclambda/handler"


### PR DESCRIPTION
This changes the output structure from 

`y/m/d/STREAM_filename.parquet`

to

`STREAM/y/m/d/filename.parquet`

This structure is preferable, since it makes it very easy for the lambda listening to output from this one to know if it should wake up or not. The downside is that this makes it a little less convenient to read data from different sources at the same time, but no more so, than from different CSVs, for instance.

I suggest this is a minor-release-worthy change, so bump to 1.2.0 after this.