### PR TITLE
Refactor lambda to expect and handle a single file at a time

### DIFF
--- a/raclambda/raclambda/handler/raclambda_handler.py
+++ b/raclambda/raclambda/handler/raclambda_handler.py
@@ -14,39 +14,33 @@ Event = Dict[str, Any]
 Context = Any
 
 
-class NothingToDo(Exception):
-    pass
-
-
 def get_env_or_raise(envvar: str) -> str:
     if (val := os.environ.get(envvar)) is None:
         raise ValueError(f"'{envvar}' not found in env")
     return val
 
 
-def parse_event_message(event: Event) -> Tuple[List[str], str]:
+def parse_event_message(event: Event) -> Tuple[str, str]:
     message: Dict[str, Any] = json.loads(event["Records"][0]["body"])
     bucket = message["bucket"]
-    objects = message["objects"]
-    return objects, bucket
+    object = message["object"]
+    return object, bucket
 
 
-def download_files(
+def download_file(
     s3_client: S3Client,
     bucket_name: str,
     path_name: str,
-    file_names: List[str],
-) -> None:
-    local_path = Path(path_name)
-
-    for file_name in file_names:
-        file_path = Path.joinpath(local_path, file_name)
-        file_path.parent.mkdir(parents=True, exist_ok=True)
-        s3_client.download_file(
-            bucket_name,
-            file_name,
-            str(file_path),
-        )
+    file_name: str,
+) -> Path:
+    file_path = Path(path_name) / file_name
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    s3_client.download_file(
+        bucket_name,
+        file_name,
+        str(file_path),
+    )
+    return file_path
 
 
 def get_rclone_config_path(
@@ -100,10 +94,8 @@ def handler(event: Event, context: Context):
         s3_client = boto3.client('s3')
 
         # Download RAC files
-        objects, rac_bucket = parse_event_message(event)
-        if objects == []:
-            raise NothingToDo
-        download_files(s3_client, rac_bucket, rac_dir, objects)
+        object, rac_bucket = parse_event_message(event)
+        file = download_file(s3_client, rac_bucket, rac_dir, object)
 
         # Setup rclone
         ssm_client = boto3.client("ssm")
@@ -120,15 +112,12 @@ def handler(event: Event, context: Context):
             sloppy=True,
         ))
 
-        # Process RAC files
-        files = [str(p) for p in Path(rac_dir).glob("*.rac")]
-
         subprocess.call([
             str(Path(__file__).parent / "rac"),
             "-parquet",
             "-project", parquet_dir,
             "-dregs", dregs_dir,
-            *files,
+            str(file),
         ])
 
         # Upload Parquet files

--- a/raclambda/raclambda/handler/raclambda_handler.py
+++ b/raclambda/raclambda/handler/raclambda_handler.py
@@ -93,7 +93,7 @@ def handler(event: Event, context: Context):
     ) as parquet_dir:
         s3_client = boto3.client('s3')
 
-        # Download RAC files
+        # Download RAC file
         object, rac_bucket = parse_event_message(event)
         file = download_file(s3_client, rac_bucket, rac_dir, object)
 

--- a/raclambda/raclambda/raclambda_stack.py
+++ b/raclambda/raclambda/raclambda_stack.py
@@ -69,8 +69,8 @@ class RacLambdaStack(Stack):
             timeout=lambda_timeout,
             architecture=lambda_.Architecture.X86_64,
             runtime=lambda_.Runtime.PYTHON_3_9,
-            memory_size=4096,
-            ephemeral_storage_size=Size.mebibytes(4096),
+            memory_size=1024,
+            ephemeral_storage_size=Size.mebibytes(1024),
             environment={
                 "RAC_DREGS": dregs_bucket.bucket_name,
                 "RAC_OUTPUT": output_bucket.bucket_name,


### PR DESCRIPTION
Part of https://github.com/innosat-mats/level1a-platform/issues/14

It now expects notifications to include an `object` rather than multiple `objects`, and handles that one accordingly