### PR TITLE
Partition by hour

### DIFF
--- a/internal/exports/parquet_writer_test.go
+++ b/internal/exports/parquet_writer_test.go
@@ -34,8 +34,8 @@ func Test_parquetName(t *testing.T) {
 		args args
 		want string
 	}{
-		{"Case 1", args{".", record, stream}, filepath.FromSlash("STAT/1980/1/5/File1.parquet")},
-		{"Case 2", args{"my/dir", record, stream}, filepath.FromSlash("my/dir/STAT/1980/1/5/File1.parquet")},
+		{"Case 1", args{".", record, stream}, filepath.FromSlash("STAT/1980/1/5/23/File1.parquet")},
+		{"Case 2", args{"my/dir", record, stream}, filepath.FromSlash("my/dir/STAT/1980/1/5/23/File1.parquet")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -291,7 +291,7 @@ func TestParquetCallbackFactoryCreator(t *testing.T) {
 
 			for _, want := range tt.wantFiles {
 				// Test each output for file name
-				savePath := filepath.Join(dir, want.prefix, "1980", "1", "5")
+				savePath := filepath.Join(dir, want.prefix, "1980", "1", "5", "23")
 				path := filepath.Join(savePath, want.base)
 				_, err := os.ReadFile(path)
 				if err != nil {

--- a/internal/timeseries/parquet_collection.go
+++ b/internal/timeseries/parquet_collection.go
@@ -32,6 +32,7 @@ func ParquetName(pkg *common.DataRecord, stream OutStream) string {
 		fmt.Sprintf("%v", tmTime.Year()),
 		fmt.Sprintf("%v", int(tmTime.Month())),
 		fmt.Sprintf("%v", tmTime.Day()),
+		fmt.Sprintf("%v", tmTime.Hour()),
 	)
 	baseName := filepath.Base(pkg.Origin.Name)
 	ext := filepath.Ext(pkg.Origin.Name)

--- a/internal/timeseries/parquet_collection_test.go
+++ b/internal/timeseries/parquet_collection_test.go
@@ -46,7 +46,7 @@ func TestParquetCollection_Write(t *testing.T) {
 			},
 			false,
 			[]string{
-				filepath.FromSlash("STAT/1980/1/5/test1.parquet"),
+				filepath.FromSlash("STAT/1980/1/5/23/test1.parquet"),
 			},
 		},
 		{
@@ -71,8 +71,8 @@ func TestParquetCollection_Write(t *testing.T) {
 			},
 			false,
 			[]string{
-				filepath.FromSlash("HTR/1980/1/5/test1.parquet"),
-				filepath.FromSlash("STAT/1980/1/5/test1.parquet"),
+				filepath.FromSlash("HTR/1980/1/5/23/test1.parquet"),
+				filepath.FromSlash("STAT/1980/1/5/23/test1.parquet"),
 			},
 		},
 		{
@@ -97,8 +97,8 @@ func TestParquetCollection_Write(t *testing.T) {
 			},
 			false,
 			[]string{
-				filepath.FromSlash("STAT/1980/1/5/test1.parquet"),
-				filepath.FromSlash("STAT/1980/1/5/test2.parquet"),
+				filepath.FromSlash("STAT/1980/1/5/23/test1.parquet"),
+				filepath.FromSlash("STAT/1980/1/5/23/test2.parquet"),
 			},
 		},
 	}

--- a/raclambda/app.py
+++ b/raclambda/app.py
@@ -10,7 +10,7 @@ import aws_cdk as cdk
 from raclambda.raclambda_stack import RacLambdaStack
 
 
-RAC_VERSION = "v1.2.0"
+RAC_VERSION = "v1.3.0"
 RAC_OS = "Linux"
 RAC_URL = f"https://github.com/innosat-mats/rac-extract-payload/releases/download/{RAC_VERSION}/Rac_for_{RAC_OS}.tar.gz"  # noqa: E501
 RAC_DIR = "./raclambda/handler"
@@ -37,7 +37,7 @@ RacLambdaStack(
     app,
     "RacLambdaStack",
     input_bucket_name="ops-payload-level0-source",
-    output_bucket_name="ops-payload-level0-v0.1",
+    output_bucket_name="ops-payload-level0-v0.2",
     queue_arn_export_name="L0RACFetcherStackOutputQueue",
     config_ssm_name="/rclone/l0-fetcher",
     rclone_arn="arn:aws:lambda:eu-north-1:671150066425:layer:rclone-amd64:1",

--- a/raclambda/raclambda/handler/raclambda_handler.py
+++ b/raclambda/raclambda/handler/raclambda_handler.py
@@ -67,7 +67,6 @@ def format_rclone_command(
     config_path: str,
     source: str,
     destination: str,
-    sloppy: bool = False
 ) -> List[str]:
     cmd = [
         "rclone",
@@ -76,9 +75,8 @@ def format_rclone_command(
         "copy",
         source,
         destination,
+        "--size-only"
     ]
-    if sloppy:
-        cmd.append("--size-only")
 
     return cmd
 

--- a/raclambda/raclambda/handler/raclambda_handler.py
+++ b/raclambda/raclambda/handler/raclambda_handler.py
@@ -61,6 +61,7 @@ def format_rclone_command(
     config_path: str,
     source: str,
     destination: str,
+    sloppy: bool = False,
 ) -> List[str]:
     cmd = [
         "rclone",
@@ -69,9 +70,9 @@ def format_rclone_command(
         "copy",
         source,
         destination,
-        "--size-only"
     ]
-
+    if sloppy:
+        cmd.append("--size-only")
     return cmd
 
 


### PR DESCRIPTION
Resolves #169

Before deploying (which is done automatically when a new tag is created, but not when merging) buckets should be created the following steps in the chain coordinated with new buckets both for input and output.

It would also be nice if #170 was finished before deploying, so that we can make a quick re-run.