### PR TITLE
Lock linux build env to 20.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-latest, macos-latest]
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/raclambda/app.py
+++ b/raclambda/app.py
@@ -10,7 +10,7 @@ import aws_cdk as cdk
 from raclambda.raclambda_stack import RacLambdaStack
 
 
-RAC_VERSION = "v1.3.0"
+RAC_VERSION = "v1.3.1"
 RAC_OS = "Linux"
 RAC_URL = f"https://github.com/innosat-mats/rac-extract-payload/releases/download/{RAC_VERSION}/Rac_for_{RAC_OS}.tar.gz"  # noqa: E501
 RAC_DIR = "./raclambda/handler"


### PR DESCRIPTION
This looks linux build environment to 20.04, which is hopefully compatible with the Amazon Linux 2-based run time environments.