### PR TITLE
Only partition ccd hourly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-latest, macos-latest]
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/internal/timeseries/parquet_collection.go
+++ b/internal/timeseries/parquet_collection.go
@@ -32,8 +32,13 @@ func ParquetName(pkg *common.DataRecord, stream OutStream) string {
 		fmt.Sprintf("%v", tmTime.Year()),
 		fmt.Sprintf("%v", int(tmTime.Month())),
 		fmt.Sprintf("%v", tmTime.Day()),
-		fmt.Sprintf("%v", tmTime.Hour()),
 	)
+	if stream.String() == "CCD" {
+		prefix = filepath.Join(
+			prefix,
+			fmt.Sprintf("%v", tmTime.Hour()),
+		)
+	}
 	baseName := filepath.Base(pkg.Origin.Name)
 	ext := filepath.Ext(pkg.Origin.Name)
 	name := fmt.Sprintf("%v.parquet", strings.TrimSuffix(baseName, ext))

--- a/internal/timeseries/parquet_collection_test.go
+++ b/internal/timeseries/parquet_collection_test.go
@@ -46,7 +46,7 @@ func TestParquetCollection_Write(t *testing.T) {
 			},
 			false,
 			[]string{
-				filepath.FromSlash("STAT/1980/1/5/23/test1.parquet"),
+				filepath.FromSlash("STAT/1980/1/5/test1.parquet"),
 			},
 		},
 		{
@@ -71,8 +71,8 @@ func TestParquetCollection_Write(t *testing.T) {
 			},
 			false,
 			[]string{
-				filepath.FromSlash("HTR/1980/1/5/23/test1.parquet"),
-				filepath.FromSlash("STAT/1980/1/5/23/test1.parquet"),
+				filepath.FromSlash("HTR/1980/1/5/test1.parquet"),
+				filepath.FromSlash("STAT/1980/1/5/test1.parquet"),
 			},
 		},
 		{
@@ -97,8 +97,35 @@ func TestParquetCollection_Write(t *testing.T) {
 			},
 			false,
 			[]string{
-				filepath.FromSlash("STAT/1980/1/5/23/test1.parquet"),
-				filepath.FromSlash("STAT/1980/1/5/23/test2.parquet"),
+				filepath.FromSlash("STAT/1980/1/5/test1.parquet"),
+				filepath.FromSlash("STAT/1980/1/5/test2.parquet"),
+			},
+		},
+		{
+			"CCD is partitioned by hour",
+			[]common.DataRecord{
+				{
+					Origin:         &common.OriginDescription{Name: "test1"},
+					RamsesHeader:   &ramses.Ramses{},
+					RamsesTMHeader: &ramses.TMHeader{},
+					SourceHeader:   &innosat.SourcePacketHeader{},
+					TMHeader:       &innosat.TMHeader{},
+					RID:            aez.CCD3,
+					Data: &aez.CCDImage{
+						PackData: &aez.CCDImagePackData{
+							JPEGQ: aez.JPEGQUncompressed16bit,
+							NCOL:  1,
+							NROW:  2,
+							EXPTS: 6,
+						},
+						ImageFileName: "File1_6000000000_3.png",
+					},
+					Buffer: []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+				},
+			},
+			false,
+			[]string{
+				filepath.FromSlash("CCD/1980/1/5/23/test1.parquet"),
 			},
 		},
 	}

--- a/raclambda/app.py
+++ b/raclambda/app.py
@@ -10,7 +10,7 @@ import aws_cdk as cdk
 from raclambda.raclambda_stack import RacLambdaStack
 
 
-RAC_VERSION = "v1.3.1"
+RAC_VERSION = "v1.4.0"
 RAC_OS = "Linux"
 RAC_URL = f"https://github.com/innosat-mats/rac-extract-payload/releases/download/{RAC_VERSION}/Rac_for_{RAC_OS}.tar.gz"  # noqa: E501
 RAC_DIR = "./raclambda/handler"
@@ -37,7 +37,7 @@ RacLambdaStack(
     app,
     "RacLambdaStack",
     input_bucket_name="ops-payload-level0-source",
-    output_bucket_name="ops-payload-level0-v0.2",
+    output_bucket_name="ops-payload-level0-v0.3",
     queue_arn_export_name="L0RACFetcherStackOutputQueue",
     config_ssm_name="/rclone/l0-fetcher",
     rclone_arn="arn:aws:lambda:eu-north-1:671150066425:layer:rclone-amd64:1",

--- a/raclambda/app.py
+++ b/raclambda/app.py
@@ -10,7 +10,7 @@ import aws_cdk as cdk
 from raclambda.raclambda_stack import RacLambdaStack
 
 
-RAC_VERSION = "v1.3.0"
+RAC_VERSION = "v1.3.1"
 RAC_OS = "Linux"
 RAC_URL = f"https://github.com/innosat-mats/rac-extract-payload/releases/download/{RAC_VERSION}/Rac_for_{RAC_OS}.tar.gz"  # noqa: E501
 RAC_DIR = "./raclambda/handler"


### PR DESCRIPTION
This updates the partitioning to use hourly partitioning only for CCD files. Needs to be re-run, but should not affect rest of pipeline if done in the right order.

For convenience, should be deployed when we know we have a good while before next dump of files on the FTP (not crucial).